### PR TITLE
MWPW-142253 remove unnecessary style since it's being set by milo

### DIFF
--- a/express/styles/styles.css
+++ b/express/styles/styles.css
@@ -543,10 +543,6 @@ a:any-link {
   font-weight: 600;
 }
 
-img {
-  max-width: 100%;
-}
-
 .section > .content h1, .section > .content h2, .section > .content h3, .section > .content h4 {
   text-align: center;
 }


### PR DESCRIPTION
remove unnecessary style since milo is setting it already. 
This is being removed as the style was added as part of this PR to the old repo - https://github.com/adobecom/express/pull/956 

Resolves: [MWPW-142253](https://jira.corp.adobe.com/browse/MWPW-142253)

Test URLs:
- Pre Migration Link: https://adobe.com/express/feature/image/remove-background
- Before: https://main--express-milo--adobecom.hlx.page/express/feature/image/remove-background
- After: https://vhargrave-mwpw-142253-image-refactoring--express-milo--adobecom.hlx.page/express/feature/image/remove-background
