### PR TITLE
MWPW-154535 fix padding columns

### DIFF
--- a/express/blocks/ax-columns/ax-columns.css
+++ b/express/blocks/ax-columns/ax-columns.css
@@ -41,7 +41,7 @@
   padding-right: 0;
 }
 
-.ax-columns:last-child:not(.highlight, .top.center, .fullsize, .light, .dark, .numbered) {
+.ax-columns:last-child:not(.highlight, .top.center, .fullsize, .light, .dark, .numbered, .centered) {
   padding-bottom: 40px;
 }
 


### PR DESCRIPTION
Fix issues reported during testing. 

Resolves: [MWPW-154535](https://jira.corp.adobe.com/browse/MWPW-154535)

Test URLs:
**Padding under the columns centered wasn't quite right**
Before: https://main--express-milo--adobecom.hlx.page/express/
After: https://mwpw-154535-fixes-sprint6--express-milo--adobecom.hlx.live/kr/express/create/advertisement

**The issue that was reported here was that images on the blog pages were aligned left, but these issues were all fixed with the work on blog.** 
Before: https://main--express-milo--adobecom.hlx.page/express/learn/blog/social-media-branding-strategy
After: https://mwpw-154535-fixes-sprint6--express-milo--adobecom.hlx.page/express/learn/blog/social-media-branding-strategy