### PR TITLE
Update config.json to include Localize v2 option

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -34,6 +34,16 @@
     },
     {
       "containerId": "tools",
+      "id": "localize-2",
+      "title": "Localize project (V2)",
+      "environments": [ "edit" ],
+      "url": "https://main--express-milo.hlx.page/tools/loc?milolibs=locui",
+      "passReferrer": true,
+      "passConfig": true,
+      "includePaths": [ "**.xlsx**" ]
+    },
+    {
+      "containerId": "tools",
       "title": "Send to CaaS",
       "id": "sendtocaas",
       "environments": ["dev","preview", "live", "prod"],


### PR DESCRIPTION
Adding `Localize project (V2)` to sidekick tools dropdown.

Resolves: [MWPW-156695](https://jira.corp.adobe.com/browse/MWPW-156695)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/
- After: https://rgclayton-localize-v2-option--express-milo--adobecom.hlx.page/express/
