### PR TITLE
Corrects loc v2 url for sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -37,7 +37,7 @@
       "id": "localize-2",
       "title": "Localize project (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--express-milo.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--express-milo--adobecom.hlx.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
Corrects a typo in the URL for for sidekick localization v2.

Resolves: [MWPW-156695](https://jira.corp.adobe.com/browse/MWPW-156695)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/
- After: https://sidekick-locurl-fix--express-milo--adobecom.hlx.page/express/
