### PR TITLE
Mwpw 143414 library config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -12,6 +12,14 @@
       "includePaths": [ "**.docx**", "**.xlsx**" ]
     },
     {
+      "id": "docs",
+      "title": "Docs",
+      "url": "https://main--express--adobecom.hlx.live/docs/",
+      "environments": [ "edit" ],
+      "excludePaths": [ "/**" ],
+      "includePaths": [ "**.docx**" ]
+    },
+    {
       "id": "library",
       "title": "Library",
       "environments": [

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,17 @@
 {
   "plugins": [
     {
+      "id": "path",
+      "title": "Path",
+      "environments": [ "edit" ],
+      "url": "https://milo.adobe.com/tools/path-finder",
+      "isPalette": true,
+      "passReferrer": true,
+      "passConfig": true,
+      "paletteRect": "top: 50%; left: 50%; transform: translate(-50%,-50%); height: 84px; width: 900px; overflow: hidden; border-radius: 6px; box-shadow: 0 20px 35px 0px rgba(0, 0, 0, 0.5);",
+      "includePaths": [ "**.docx**", "**.xlsx**" ]
+    },
+    {
       "id": "library",
       "title": "Library",
       "environments": [


### PR DESCRIPTION
Adds a few more features to the sidekick that we have in the old project (Docs) and that is offered in Milo (Path)

Resolves: [MWPW-143414](https://jira.corp.adobe.com/browse/MWPW-143414)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/
- After: https://MWPW-143414-library-config--express-milo--adobecom.hlx.page/express/
