### PR TITLE
iPad GA - quotes block singular variant Milo

### DIFF
--- a/express/blocks/quotes/quotes.css
+++ b/express/blocks/quotes/quotes.css
@@ -125,11 +125,11 @@ main .quotes.singular .quote-container .mobile-container {
 }
 
 main .quotes.singular .quote-container .mobile-container .quote {
-  max-width: 375px;
+  max-width: unset;
 }
 
 /* toggles between the mobile and desktop layout */
-@media (min-width: 600px) {
+@media (min-width: 768px) {
   main .quotes.singular .quote-container .desktop-container {
     display: block;
   }
@@ -196,7 +196,7 @@ main .quotes.singular .mobile-container .author-photo picture img {
 }
 
 main .quotes.singular .quote-details {
-  width: 90%;
+  margin: 0 16px;
   font-size: 22px;
   font-weight: 800;
   text-align: left;
@@ -225,25 +225,29 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
   margin-right: 15px;
 }
 
-@media (min-width: 600px) {
+@media (min-width: 768px) {
+  main .quotes.singular .quote-details {
+    margin: 0 32px;
+  }
   main .quotes.singular .quote {
-    width: 80%;
+    width: 83.3%;
     min-height: 315px;
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1280px) {
   main .quotes.singular .quote {
     width: 75%;
     max-width: 830px;
     font-weight: 600;
   }
   main .quotes.singular .quote-details {
+    margin: 0 40px;
     font-size: 28px;
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1680px) {
   main .quotes.singular .quote {
     max-width: 1024px;
   }
@@ -263,23 +267,22 @@ main .quotes.singular .mobile-container .author-panel .author-photo {
   color: var(--color-black);
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1280px) {
   .quotes-wrapper, .section .content:has(+ .quotes-wrapper) {
     max-width: 724px;
   }
-
   .quotes {
     flex-direction: row;
     gap: 16px;
   }
-
   .quotes .quote {
     flex: 1;
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1680px) {
   .quotes-wrapper, .section .content:has(+ .quotes-wrapper) {
     max-width: 1024px;
+    margin: auto;
   }
 }

--- a/express/blocks/quotes/quotes.js
+++ b/express/blocks/quotes/quotes.js
@@ -37,7 +37,7 @@ export default function decorate($block) {
       const backgroundDesktopCSS = `no-repeat calc(-400px + 25%) -20px / 640px url("${backgroundUrl}"), no-repeat calc(450px + 75%) -20px / 640px url("${backgroundUrl}")`;
       $desktopContainerBackground.style.background = backgroundDesktopCSS;
 
-      const backgroundMobileCSS = `no-repeat -20px -20px / 750px url("${backgroundUrl}")`;
+      const backgroundMobileCSS = `no-repeat -80px -48px / 750px url("${backgroundUrl}")`;
       $mobileContainerBackground.style.background = backgroundMobileCSS;
 
       $rows.shift();


### PR DESCRIPTION
iPad GA - the new S2 breakpoints and margins migrated to Milo

Resolves: [MWPW-163277](https://jira.corp.adobe.com/browse/MWPW-163277)

Test URLs:
- Pre Migration Link: https://main--express-milo--adobecom.hlx.page/docs/library/kitchen-sink/quotes
- Before: https://ipad-ga-quotes-before--express-milo--adobecom.hlx.page/docs/library/kitchen-sink/quotes
- After: https://ipad-ga-quotes-after--express-milo--adobecom.hlx.page/docs/library/kitchen-sink/quotes
