### PR TITLE
Accessible pricing tooltip

### DIFF
--- a/express/code/blocks/pricing-cards/pricing-cards.css
+++ b/express/code/blocks/pricing-cards/pricing-cards.css
@@ -192,8 +192,8 @@ End border style variants
   bottom: 100%;
   min-width: 200px;
   left: -105px;
-  width: fit-content;
   margin-bottom: 5px;
+  user-select: text;
   transition: bottom 0.5s;
   width: 100%;
 }

--- a/express/code/blocks/pricing-cards/pricing-cards.css
+++ b/express/code/blocks/pricing-cards/pricing-cards.css
@@ -163,6 +163,18 @@ Border style variants
 End border style variants
 */
 
+.pricing-cards .tooltip > button:focus-within .tooltip-text {
+  opacity: 1;
+}
+
+.pricing-cards .tooltip>button {
+  border: none;
+  background-color: transparent;
+  padding: 0px;
+  font-family: "adobe-clean";
+  position: relative;
+}
+
 .pricing-cards .tooltip-icon {
   position: relative;
   top: 2px;
@@ -186,13 +198,11 @@ End border style variants
   color: white;
   border-radius: 8px;
   position: absolute;
-  bottom: 100%;
-  min-width: 200px;
-  left: -105px;
-  width: fit-content;
-  margin-bottom: 19px;
+  bottom: 100%; 
+  width:  200px;
+  left: -105px; 
+  margin-bottom: 5px;
   transition: bottom 0.5s;
-  width: 100%;
 }
 
 .pricing-cards .tooltip-text::after {
@@ -205,12 +215,11 @@ End border style variants
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   border-top: 5px solid black;
-
 }
 
 .pricing-cards .tooltip-text.overflow-left::after {
   right: inherit;
-  left: 20px;
+  left: 23px;
 }
 
 .pricing-cards .tooltip-text.overflow-right::after {

--- a/express/code/blocks/pricing-cards/pricing-cards.css
+++ b/express/code/blocks/pricing-cards/pricing-cards.css
@@ -163,18 +163,6 @@ Border style variants
 End border style variants
 */
 
-.pricing-cards .tooltip > button:focus-within .tooltip-text {
-  opacity: 1;
-}
-
-.pricing-cards .tooltip>button {
-  border: none;
-  background-color: transparent;
-  padding: 0px;
-  font-family: "adobe-clean";
-  position: relative;
-}
-
 .pricing-cards .tooltip-icon {
   position: relative;
   top: 2px;
@@ -187,10 +175,13 @@ End border style variants
 .pricing-cards .tooltip-text.overflow-right {
   left: inherit;
   right: -20px;
-
 }
+
+.pricing-cards .tooltip > button:focus-within .tooltip-text {
+  opacity: 1;
+}
+
 .pricing-cards .tooltip-text {
-  pointer-events: none;
   opacity: 0;
   padding: 8px;
   z-index: 10;
@@ -198,12 +189,31 @@ End border style variants
   color: white;
   border-radius: 8px;
   position: absolute;
-  bottom: 100%; 
-  width:  200px;
-  left: -105px; 
+  bottom: 100%;
+  min-width: 200px;
+  left: -105px;
+  width: fit-content;
   margin-bottom: 5px;
   transition: bottom 0.5s;
+  width: 100%;
 }
+
+.pricing-cards .tooltip>button {
+  border: none;
+  background-color: transparent;
+  padding: 0px;
+  font-family: "adobe-clean";
+  position: relative;
+}
+
+
+.pricing-cards .tooltip  button.hover .tooltip-text {
+  opacity: 1;
+} 
+
+.pricing-cards .tooltip-text.hover {
+  opacity: 1;
+} 
 
 .pricing-cards .tooltip-text::after {
   content: '';
@@ -215,11 +225,12 @@ End border style variants
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   border-top: 5px solid black;
+
 }
 
 .pricing-cards .tooltip-text.overflow-left::after {
   right: inherit;
-  left: 23px;
+  left: 20px;
 }
 
 .pricing-cards .tooltip-text.overflow-right::after {

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -345,7 +345,7 @@ function handleTooltip(pricingArea) {
   icon.append(span);
   const iconWrapper = createTag('button');
   icon.setAttribute('tabindex', 1);
-  iconWrapper.setAttribute('aria-label',tooltipText);
+  iconWrapper.setAttribute('aria-label', tooltipText);
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -345,6 +345,7 @@ function handleTooltip(pricingArea) {
   icon.append(span);
   const iconWrapper = createTag('button');
   icon.setAttribute('tabindex', 1);
+  iconWrapper.setAttribute('aria-label',tooltipText);
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -311,7 +311,7 @@ function adjustElementPosition() {
     if (rect.right > window.innerWidth) {
       element.classList.remove('overflow-left');
       element.classList.add('overflow-right');
-    } else if (rect.left < 0) {
+    } else if (rect.left < 40) {
       element.classList.remove('overflow-right');
       element.classList.add('overflow-left');
     } else {
@@ -343,7 +343,8 @@ function handleTooltip(pricingArea) {
   span.innerText = tooltipText;
   const icon = getIconElementDeprecated('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
-  const iconWrapper = createTag('span');
+  const iconWrapper = createTag('button');
+  icon.setAttribute('tabindex', 1);
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -311,7 +311,7 @@ function adjustElementPosition() {
     if (rect.right > window.innerWidth) {
       element.classList.remove('overflow-left');
       element.classList.add('overflow-right');
-    } else if (rect.left < 40) {
+    } else if (rect.left < 0) {
       element.classList.remove('overflow-right');
       element.classList.add('overflow-left');
     } else {

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -348,6 +348,27 @@ function handleTooltip(pricingArea) {
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);
+
+  iconWrapper.addEventListener('mouseover', () => {
+    iconWrapper.classList.add('hover')
+  })
+  iconWrapper.addEventListener('mouseleave', () => {
+    setTimeout(() => { 
+      iconWrapper.classList.remove('hover')
+     }, 500)
+  })
+  span.addEventListener('mouseenter', () => {
+    span.classList.add('hover')
+  })
+  span.addEventListener('mouseleave', () => {
+    span.classList.remove('hover')
+  })
+  document.addEventListener('keydown', (e) => {
+    if (e.key === "Escape") {
+      document.activeElement.blur()
+      iconWrapper.classList.remove('hover')
+    }
+  })
 }
 
 async function handlePrice(pricingArea, specialPromo, groupID, legacyVersion) {

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -350,25 +350,29 @@ function handleTooltip(pricingArea) {
   tooltipDiv.append(iconWrapper);
 
   iconWrapper.addEventListener('mouseover', () => {
-    iconWrapper.classList.add('hover')
-  })
+    iconWrapper.classList.add('hover');
+  });
+
   iconWrapper.addEventListener('mouseleave', () => {
-    setTimeout(() => { 
-      iconWrapper.classList.remove('hover')
-     }, 500)
-  })
+    setTimeout(() => {
+      iconWrapper.classList.remove('hover');
+    }, 500);
+  });
+
   span.addEventListener('mouseenter', () => {
-    span.classList.add('hover')
-  })
+    span.classList.add('hover');
+  });
+
   span.addEventListener('mouseleave', () => {
-    span.classList.remove('hover')
-  })
+    span.classList.remove('hover');
+  });
+
   document.addEventListener('keydown', (e) => {
-    if (e.key === "Escape") {
-      document.activeElement.blur()
-      iconWrapper.classList.remove('hover')
+    if (e.key === 'Escape') {
+      document.activeElement.blur();
+      iconWrapper.classList.remove('hover');
     }
-  })
+  });
 }
 
 async function handlePrice(pricingArea, specialPromo, groupID, legacyVersion) {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -313,6 +313,10 @@ main .section>.simplified-pricing-cards-wrapper {
 
 /* Tooltip CSS */
 
+.simplified-pricing-cards .tooltip > button:focus-within .tooltip-text {
+    opacity: 1;
+}
+
 .simplified-pricing-cards .tooltip-icon {
     position: relative;
     top: 2px;
@@ -327,13 +331,20 @@ main .section>.simplified-pricing-cards-wrapper {
     border-radius: 8px;
     position: absolute;
     bottom: 100%;
-    min-width: 200px;
-    left: -105px;
-    width: fit-content;
-    margin-bottom: 19px;
+    width:  200px;
+    left: -105px; 
+    margin-bottom: 10px;
     transition: bottom 0.5s;
     pointer-events: none;
 }
+
+.simplified-pricing-cards .tooltip>button {
+    border: none;
+    background-color: transparent;
+    padding: 0px;
+    font-family: "adobe-clean";
+    position: relative;
+  }
 
 .simplified-pricing-cards .tooltip-text.overflow-left {
     right: inherit;
@@ -349,14 +360,16 @@ main .section>.simplified-pricing-cards-wrapper {
     content: '';
     position: absolute;
     bottom: -5px;
-    left: 50%;
-    border: 5px solid transparent;
-    border-top-color: var(--color-black)
+    left: -105px; 
+    border-top-color: var(--color-black);
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid black;
 }
 
 .simplified-pricing-cards .tooltip-text.overflow-left::after {
     right: inherit;
-    left: 20px;
+    left: 23px;
 }
 
 .simplified-pricing-cards .tooltip-text.overflow-right::after {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -268,6 +268,7 @@ main .section>.simplified-pricing-cards-wrapper {
     width: 100%;
 }
 
+
 .simplified-pricing-cards .tooltip {
     position: relative;
     display: inline;
@@ -277,9 +278,13 @@ main .section>.simplified-pricing-cards-wrapper {
     position: relative;
 }
 
-.simplified-pricing-cards .tooltip .icon:hover~.tooltip-text {
+.simplified-pricing-cards .tooltip  button.hover .tooltip-text {
     opacity: 1;
-}
+} 
+
+.simplified-pricing-cards .tooltip-text.hover {
+    opacity: 1;
+} 
 
 .simplified-pricing-cards .toggle-switch {
     display: block;
@@ -333,9 +338,8 @@ main .section>.simplified-pricing-cards-wrapper {
     bottom: 100%;
     width:  200px;
     left: -105px; 
-    margin-bottom: 10px;
+    margin-bottom: 5px;
     transition: bottom 0.5s;
-    pointer-events: none;
 }
 
 .simplified-pricing-cards .tooltip>button {
@@ -360,7 +364,7 @@ main .section>.simplified-pricing-cards-wrapper {
     content: '';
     position: absolute;
     bottom: -5px;
-    left: 105px; 
+    left: 107px; 
     border-top-color: var(--color-black);
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -360,7 +360,7 @@ main .section>.simplified-pricing-cards-wrapper {
     content: '';
     position: absolute;
     bottom: -5px;
-    left: -105px; 
+    left: 105px; 
     border-top-color: var(--color-black);
     border-left: 5px solid transparent;
     border-right: 5px solid transparent;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -339,6 +339,7 @@ main .section>.simplified-pricing-cards-wrapper {
     width:  200px;
     left: -105px; 
     margin-bottom: 5px;
+    user-select: text;
     transition: bottom 0.5s;
 }
 

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -51,7 +51,7 @@ export function handleTooltip(pricingArea) {
   const icon = getIconElementDeprecated('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
   const iconWrapper = createTag('button');
-  iconWrapper.setAttribute('aria-label',tooltipText);
+  iconWrapper.setAttribute('aria-label', tooltipText);
   icon.setAttribute('tabindex', 1);
   iconWrapper.append(icon);
   iconWrapper.append(span);

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -57,6 +57,27 @@ export function handleTooltip(pricingArea) {
   tooltipDiv.append(iconWrapper);
   iconWrapper.addEventListener('click', adjustElementPosition);
   window.addEventListener('resize', adjustElementPosition);
+
+  iconWrapper.addEventListener('mouseover', () => {
+    iconWrapper.classList.add('hover')
+  })
+  iconWrapper.addEventListener('mouseleave', () => {
+    setTimeout(() => { 
+      iconWrapper.classList.remove('hover')
+     }, 500)
+  })
+  span.addEventListener('mouseenter', () => {
+    span.classList.add('hover')
+  })
+  span.addEventListener('mouseleave', () => {
+    span.classList.remove('hover')
+  })
+  document.addEventListener('keydown', (e) => {
+    if (e.key === "Escape") {
+      document.activeElement.blur()
+      iconWrapper.classList.remove('hover')
+    }
+  })
 }
 
 function getHeightWithoutPadding(element) {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -59,25 +59,29 @@ export function handleTooltip(pricingArea) {
   window.addEventListener('resize', adjustElementPosition);
 
   iconWrapper.addEventListener('mouseover', () => {
-    iconWrapper.classList.add('hover')
-  })
+    iconWrapper.classList.add('hover');
+  });
+
   iconWrapper.addEventListener('mouseleave', () => {
-    setTimeout(() => { 
-      iconWrapper.classList.remove('hover')
-     }, 500)
-  })
+    setTimeout(() => {
+      iconWrapper.classList.remove('hover');
+    }, 500);
+  });
+
   span.addEventListener('mouseenter', () => {
-    span.classList.add('hover')
-  })
+    span.classList.add('hover');
+  });
+
   span.addEventListener('mouseleave', () => {
-    span.classList.remove('hover')
-  })
+    span.classList.remove('hover');
+  });
+
   document.addEventListener('keydown', (e) => {
-    if (e.key === "Escape") {
-      document.activeElement.blur()
-      iconWrapper.classList.remove('hover')
+    if (e.key === 'Escape') {
+      document.activeElement.blur();
+      iconWrapper.classList.remove('hover');
     }
-  })
+  });
 }
 
 function getHeightWithoutPadding(element) {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -51,6 +51,7 @@ export function handleTooltip(pricingArea) {
   const icon = getIconElementDeprecated('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
   const iconWrapper = createTag('button');
+  iconWrapper.setAttribute('aria-label',tooltipText);
   icon.setAttribute('tabindex', 1);
   iconWrapper.append(icon);
   iconWrapper.append(span);

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -50,7 +50,8 @@ export function handleTooltip(pricingArea) {
   span.innerText = tooltipText;
   const icon = getIconElementDeprecated('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
-  const iconWrapper = createTag('span');
+  const iconWrapper = createTag('button');
+  icon.setAttribute('tabindex', 1);
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "wtr \"./test/**/*.test.js\" --node-resolve --port=2000 --coverage",
     "test:watch": "npm test -- --watch",
     "lint": "npm run lint:js && npm run lint:css",
-    "lint:fix": "npm run lint:js --fix && npm run lint:css --fix",
+    "lint:fix": "npm run lint:js -- --fix && npm run lint:css --fix",
     "lint:js": "eslint .",
     "lint:css": "stylelint 'blocks/**/*.css' 'express/code/styles/*.css'"
   },


### PR DESCRIPTION
**Fixes following issues|Adds following features:**
- Issue/Feature 1

    changed the wrapper element to button so that it is focusable
    tooltip now stays open if focused via keyboard, can be dismissed by changing focus.
    revamped some CSS
    added missing caret at the bottom in the simplified version of the tooltip

**Resolves:**  https://jira.corp.adobe.com/browse/MWPW-160772
   

**Pages to check for regression and performance:**
- https://accessible-pricing-tooltip--express-milo--adobecom.hlx.page/express/
- https://accessible-pricing-tooltip--express-milo--adobecom.hlx.page/express/pricing
- https://accessible-pricing-tooltip--express-milo--adobecom.hlx.page/de/express/pricing

 Visit the two pages above on the three device resolutions and press tab until the tooltip shows up. Verify that it is completely visible inside the device screen and that it goes away when you tab again.
 
<img width="553" alt="Screenshot 2025-01-13 at 1 50 37 PM" src="https://github.com/user-attachments/assets/7be796e3-8f89-4293-8317-693cd53185c4" />



