### PR TITLE
Adding accessibility attributes to share button

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -127,11 +127,14 @@ async function share(branchUrl, tooltip, timeoutId) {
   }, 2500);
 }
 
-function renderShareWrapper(branchUrl) {
+function renderShareWrapper(templateInfo) {
+  const { templateTitle, branchUrl } = templateInfo;
   const text = tagCopied === 'tag copied' ? 'Copied to clipboard' : tagCopied;
   const wrapper = createTag('div', { class: 'share-icon-wrapper' });
   const shareIcon = getIconElementDeprecated('share-arrow');
   shareIcon.setAttribute('tabindex', 0);
+  shareIcon.setAttribute('role', 'button');
+  shareIcon.setAttribute('aria-label', `Share ${templateTitle}`);
   const tooltip = createTag('div', {
     class: 'shared-tooltip',
     'aria-label': text,
@@ -341,7 +344,7 @@ function renderMediaWrapper(template) {
     e.stopPropagation();
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
-      const shareWrapper = renderShareWrapper(branchUrl);
+      const shareWrapper = renderShareWrapper(templateInfo);
       mediaWrapper.append(shareWrapper);
     }
     renderedMedia.hover();
@@ -360,7 +363,7 @@ function renderMediaWrapper(template) {
     e.stopPropagation();
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
-      const shareWrapper = renderShareWrapper(branchUrl);
+      const shareWrapper = renderShareWrapper(templateInfo);
       mediaWrapper.append(shareWrapper);
       renderedMedia.hover();
     }

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -7,7 +7,7 @@ import BlockMediator from '../../scripts/block-mediator.min.js';
 let createTag; let getConfig;
 let getMetadata; let replaceKeyArray;
 let tagCopied; let editThisTemplate;
-let free;
+let free; let sharePlaceholder;
 
 function containsVideo(pages) {
   return pages.some((page) => !!page?.rendition?.video?.thumbnail?.componentId);
@@ -134,7 +134,7 @@ function renderShareWrapper(templateInfo) {
   const shareIcon = getIconElementDeprecated('share-arrow');
   shareIcon.setAttribute('tabindex', 0);
   shareIcon.setAttribute('role', 'button');
-  shareIcon.setAttribute('aria-label', `${share === 'share' ? 'Share' : share} ${templateTitle}`);
+  shareIcon.setAttribute('aria-label', `${sharePlaceholder === 'share' ? 'Share' : sharePlaceholder} ${templateTitle}`);
   const tooltip = createTag('div', {
     class: 'shared-tooltip',
     'aria-label': text,
@@ -484,7 +484,7 @@ export default async function renderTemplate(template) {
     ({ createTag, getConfig, getMetadata } = utils);
     ({ replaceKeyArray } = placeholders);
   });
-  [tagCopied, editThisTemplate, free, share] = await replaceKeyArray(['tag-copied', 'edit-this-template', 'free', 'share'], getConfig());
+  [tagCopied, editThisTemplate, free, sharePlaceholder] = await replaceKeyArray(['tag-copied', 'edit-this-template', 'free', 'share'], getConfig());
 
   const tmpltEl = createTag('div');
   if (template.assetType === 'Webpage_Template') {

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -134,7 +134,7 @@ function renderShareWrapper(templateInfo) {
   const shareIcon = getIconElementDeprecated('share-arrow');
   shareIcon.setAttribute('tabindex', 0);
   shareIcon.setAttribute('role', 'button');
-  shareIcon.setAttribute('aria-label', `Share ${templateTitle}`);
+  shareIcon.setAttribute('aria-label', `${share === 'share' ? 'Share' : share} ${templateTitle}`);
   const tooltip = createTag('div', {
     class: 'shared-tooltip',
     'aria-label': text,
@@ -484,7 +484,7 @@ export default async function renderTemplate(template) {
     ({ createTag, getConfig, getMetadata } = utils);
     ({ replaceKeyArray } = placeholders);
   });
-  [tagCopied, editThisTemplate, free] = await replaceKeyArray(['tag-copied', 'edit-this-template', 'free'], getConfig());
+  [tagCopied, editThisTemplate, free, share] = await replaceKeyArray(['tag-copied', 'edit-this-template', 'free', 'share'], getConfig());
 
   const tmpltEl = createTag('div');
   if (template.assetType === 'Webpage_Template') {


### PR DESCRIPTION
- Added `role="button"` to share button.
- Added `aria-label` to share button that contains the template/flyer name so the screen reader message is more descriptive than just saying "share now"
- See comments in JIra ticket for conversation with Taryn for full details.

Resolves: [MWPW-164905](https://jira.corp.adobe.com/browse/MWPW-164905)

Test URLs:
- Pre Migration Link: https://main--express--adobecom.hlx.page/in/express/fragments/homepage-desktop1
- Before: https://main--express-milo--adobecom.hlx.page/in/express/fragments/homepage-desktop1?martech=off
- After: https://a11y-templatex-share-button--express-milo--adobecom.hlx.page/in/express/fragments/homepage-desktop1?martech=off

**Testing notes:**
Scroll down to the section titled "Scroll-stopping templates" on the provided test page.