### PR TITLE
Mobile: How to steps carousel block not centered for DE pages.

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -231,7 +231,6 @@
 .section .ax-columns > div {
   display: flex;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
   padding: 40px 0;
 }

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -12,10 +12,8 @@
 .how-to-steps-carousel-container > div.content{
   background-color: var(--color-gray-100);
   border-radius: 40px;
-
   margin: 0 24px;
   padding: 56px 24px;
-  width: 100%;
   max-width: fit-content;
 }
 


### PR DESCRIPTION
Describe your specific features or fixes

Resolves: [MWPW-165032](https://jira.corp.adobe.com/browse/MWPW-165032)

**Before**
<img width="334" alt="before" src="https://github.com/user-attachments/assets/c6a7c1f4-c42f-4bf5-925a-fd0d82028efe" />
<img width="325" alt="before" src="https://github.com/user-attachments/assets/f195eb4c-df90-46b3-9b8d-8cb8b26d5574" />

**After**
<img width="388" alt="after" src="https://github.com/user-attachments/assets/bc095158-f7b9-413a-adf2-71fbd1d63a18" />
<img width="358" alt="after" src="https://github.com/user-attachments/assets/da851da1-18dd-4088-945e-b5bc563b6070" />

Test URLs:
- Pre Migration Link: https://adobe.com/de/express/create/chart/bar
- Before: https://main--express-milo--adobecom.aem.page/de/express/create/chart/bar
- After: https:// de-how-to-steps-carousel-center-issue--express-milo--adobecom.aem.page/de/express/create/chart/bar
