### PR TITLE
Pricing Table Upgrade

### DIFF
--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -187,68 +187,13 @@ main .section .pricing-table:has(.pricing-table.few-cols) {
 }
 main .section .pricing-table:has(.pricing-table.many-cols) {
   max-width: 1200px;
-}
-
-@media (max-width: 980px) {
-  main .section .pricing-table-wrapper,
-  main .section .pricing-table-wrapper:has(.pricing-table.few-cols),
-  main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
-    max-width: unset;
-  }
-  main .section .pricing-table-wrapper .pricing-table {
-    margin: 0px 20px;
-  }
-
-  .pricing-table {
-    margin: 0 30px;
-  }
-
-  .pricing-table .section-head {
-    display: block;
-  }
-
-  .pricing-table .section-head .col:not(.section-head-title),
-  .pricing-table .col-heading.col-1 {
-    display: none;
-  }
-
-  .pricing-table .section-row-title {
-    grid-row: 1;
-    grid-column: 1 / x;
-    background-color: var(--color-gray-100);
-  }
-
-  .pricing-table .row-heading .col:nth-child(n + 1) {
-    padding: 20px;
-  }
-}
+} 
 /* /Table Width */
 
 .pricing-table .row:not(.blank-row) {
   min-height: 80px;
 }
-
-@media (min-width: 981px) {
-  .pricing-table > .row {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  }
-
-  /* Sticky Table */
-  .pricing-table.sticky .row.row-heading.stuck {
-    width: 100vw;
-    margin-left: calc((100vw - 100%) / -2);
-    padding: 0 calc((100vw - 100%) / 2);
-    box-shadow: 0px 4px 16px 0px rgba(0, 0, 0, 0.16);
-    box-sizing: border-box;
-    transition: box-shadow 200ms linear;
-  }
-
-  .pricing-table.sticky .row.row-heading.stuck>.col {
-    border: 0;
-  }
-/* /Sticky Table */
-}
-
+ 
 /* Blank Row */
 .pricing-table .row.blank-row {
   height: 40px;
@@ -712,10 +657,58 @@ main .section .pricing-table:has(.pricing-table.many-cols) {
     top: -5.75px;
     opacity: 0.75;
   }
+  main .section .pricing-table-wrapper,
+  main .section .pricing-table-wrapper:has(.pricing-table.few-cols),
+  main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
+    max-width: unset;
+  }
+  main .section .pricing-table-wrapper .pricing-table {
+    margin: 0px 20px;
+  }
+
+  .pricing-table {
+    margin: 0 30px;
+  }
+
+  .pricing-table .section-head {
+    display: block;
+  }
+
+  .pricing-table .section-head .col:not(.section-head-title),
+  .pricing-table .col-heading.col-1 {
+    display: none;
+  }
+
+  .pricing-table .section-row-title {
+    grid-row: 1;
+    grid-column: 1 / x;
+    background-color: var(--color-gray-100);
+  }
+
+  .pricing-table .row-heading .col:nth-child(n + 1) {
+    padding: 20px;
+  }
 }
 
 
 @media (min-width: 981px) {
+  .pricing-table > .row {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  }
+
+  /* Sticky Table */
+  .pricing-table.sticky .row.row-heading.stuck {
+    width: 100vw;
+    margin-left: calc((100vw - 100%) / -2);
+    padding: 0 calc((100vw - 100%) / 2);
+    box-shadow: 0px 4px 16px 0px rgba(0, 0, 0, 0.16);
+    box-sizing: border-box;
+    transition: box-shadow 200ms linear;
+  }
+
+  .pricing-table.sticky .row.row-heading.stuck>.col {
+    border: 0;
+  }
 
   .pricing-table .row.row-heading .col:first-child p {
     font-weight: 700;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -717,3 +717,21 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     opacity: 0.75;
   }
 }
+
+
+@media (min-width: 981px) {
+  .pricing-table.seamless .row-2{
+    height: 0px;
+  } 
+
+  .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col {
+   border-bottom: none;
+   border-bottom-left-radius: 0px;
+   border-bottom-right-radius: 0px;
+  } 
+
+  .pricing-table.seamless .row-3 {
+    display: none;
+  } 
+}
+

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -156,38 +156,6 @@
   border-top: 1px solid transparent;
 }
 
-@media (min-width: 900px) {
-  .pricing-table > .row {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
-  }
-}
-
-/* Start tablet styles */
-@media (max-width: 899px) {
-  .pricing-table {
-    margin: 0 30px;
-  }
-
-  .pricing-table .section-head {
-    display: block;
-  }
-
-  .pricing-table .section-head .col:not(.section-head-title),
-  .pricing-table .col-heading.col-1 {
-    display: none;
-  }
-
-  .pricing-table .section-row-title {
-    grid-row: 1;
-    grid-column: 1 / x;
-    background-color: var(--color-gray-100);
-  }
-
-  .pricing-table .row-heading .col:nth-child(n + 1) {
-    padding: 20px;
-  }
-}
-
 @media (max-width: 400px) {
   .pricing-table {
     margin: 0 2px;
@@ -230,6 +198,29 @@ main .section .pricing-table:has(.pricing-table.many-cols) {
   main .section .pricing-table-wrapper .pricing-table {
     margin: 0px 20px;
   }
+
+  .pricing-table {
+    margin: 0 30px;
+  }
+
+  .pricing-table .section-head {
+    display: block;
+  }
+
+  .pricing-table .section-head .col:not(.section-head-title),
+  .pricing-table .col-heading.col-1 {
+    display: none;
+  }
+
+  .pricing-table .section-row-title {
+    grid-row: 1;
+    grid-column: 1 / x;
+    background-color: var(--color-gray-100);
+  }
+
+  .pricing-table .row-heading .col:nth-child(n + 1) {
+    padding: 20px;
+  }
 }
 /* /Table Width */
 
@@ -238,6 +229,10 @@ main .section .pricing-table:has(.pricing-table.many-cols) {
 }
 
 @media (min-width: 981px) {
+  .pricing-table > .row {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  }
+
   /* Sticky Table */
   .pricing-table.sticky .row.row-heading.stuck {
     width: 100vw;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -483,9 +483,8 @@ main .section .pricing-table:has(.pricing-table.many-cols) {
 .pricing-table.vertical-shading .col:nth-child(2n) {
   background: var(--shaded-color);
 }
+
 /* /Table Section Rows */
-
-
 @media (max-width: 980px) {
   .pricing-table .row:not(.blank-row) {
     min-height: 60px;
@@ -689,7 +688,6 @@ main .section .pricing-table:has(.pricing-table.many-cols) {
     padding: 20px;
   }
 }
-
 
 @media (min-width: 981px) {
   .pricing-table > .row {

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -210,16 +210,17 @@
 }
 
 /* Table Width */
-main .section .pricing-table-wrapper {
+main .section .pricing-table {
   margin: auto;
   max-width: 900px;
 }
-main .section .pricing-table-wrapper:has(.pricing-table.few-cols) {
+main .section .pricing-table:has(.pricing-table.few-cols) {
   max-width: 700px;
 }
-main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
+main .section .pricing-table:has(.pricing-table.many-cols) {
   max-width: 1200px;
 }
+
 @media (max-width: 980px) {
   main .section .pricing-table-wrapper,
   main .section .pricing-table-wrapper:has(.pricing-table.few-cols),
@@ -388,8 +389,8 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   margin: 0;
 }
 .pricing-table .row.row-heading .col .icon {
-  height: 24px;
-  width: 24px;
+  height: 20px;
+  width: 20px;
 }
 .pricing-table .row.row-heading .col > div p {
   font-size: 1.125rem;
@@ -720,6 +721,21 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 
 
 @media (min-width: 981px) {
+
+  .pricing-table .row.row-heading .col:first-child p {
+    font-weight: 700;
+    font-size: 18px;
+  }
+  
+  .pricing-table .row.row-heading .col > div p {
+    font-weight: 900;
+    font-size: 18px;
+  }
+  
+  .pricing-table.seamless {
+    width: 1100px;
+  }
+
   .pricing-table.seamless .row-2{
     height: 0px;
   } 
@@ -728,7 +744,18 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
    border-bottom: none;
    border-bottom-left-radius: 0px;
    border-bottom-right-radius: 0px;
+   border-top: none;
   } 
+
+  .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col-1 {
+    border-left: none;
+    border-top: none;
+  }
+
+  .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col-3 {
+    border-top: none;
+    border-right: none;
+  }
 
   .pricing-table.seamless .row-3 {
     display: none;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -740,7 +740,7 @@ main .section .pricing-table:has(.pricing-table.many-cols) {
     height: 0px;
   } 
 
-  .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col {
+  .pricing-table.seamless .row-1 .col {
    border-bottom: none;
    border-bottom-left-radius: 0px;
    border-bottom-right-radius: 0px;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -492,7 +492,7 @@ main .section>.simplified-pricing-cards-wrapper {
     }
 
     .simplified-pricing-cards.wide {
-        --card-width: 375px;
+        --card-width: 385px;
     }
 
     .simplified-pricing-cards .card.hide {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -491,6 +491,10 @@ main .section>.simplified-pricing-cards-wrapper {
         padding-top: 40px;
     }
 
+    .simplified-pricing-cards.wide {
+        --card-width: 397px;
+    }
+
     .simplified-pricing-cards .card.hide {
         gap: 8px;
     }

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -492,7 +492,7 @@ main .section>.simplified-pricing-cards-wrapper {
     }
 
     .simplified-pricing-cards.wide {
-        --card-width: 397px;
+        --card-width: 375px;
     }
 
     .simplified-pricing-cards .card.hide {

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -714,8 +714,8 @@ main .section:not(.xxxl-spacing-static,
   padding-bottom: 40px;
 }
 
-main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner) a.button.same-fcta,
-main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner) a.con-button.same-fcta,
+main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.button.same-fcta,
+main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.con-button.same-fcta,
 #hero a.same-fcta {
   display: none;
 }


### PR DESCRIPTION
Describe your specific features or fixes

Implements a `seamless` variant of the pricing table that matches the design for the new business hub.

Implements a `wide` variant for the simplified pricing cards to make it 400 px wide on desktop if desired by authors.

Refactors the media query cutoffs for the pricing table.

<img width="1055" alt="Screenshot 2025-01-31 at 4 14 23 PM" src="https://github.com/user-attachments/assets/645b33b8-b731-4d87-a12b-1c03df6d76de" />

<img width="1742" alt="Screenshot 2025-02-07 at 9 38 24 AM" src="https://github.com/user-attachments/assets/4e454517-a036-4d77-8555-be93456b22ad" />


Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-166366
https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-166368

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before:https://main--express-milo--adobecom.hlx.page/drafts/echen/individuals-and-teams-upgrade?martech=off
- https://main--express-milo--adobecom.hlx.page/express/pricing?martech=off
- After: https://pricing-table-upgrade--express-milo--adobecom.hlx.page/drafts/echen/individuals-and-teams-upgrade?martech=off
 - https://pricing-table-upgrade--express-milo--adobecom.hlx.page/express/pricing?martech=off
