### PR TITLE
MWPW-165757 - Fix cards text getting cutt off at widths below 360px.

### DIFF
--- a/express/code/blocks/pricing-cards/pricing-cards.css
+++ b/express/code/blocks/pricing-cards/pricing-cards.css
@@ -1,6 +1,7 @@
 :root {
   --card-width: 353px;
   --card-padding: 12px;
+  --card-max-width: calc((1200px - 32px) / 3);
 }
 
 .pricing-cards.no-visible {
@@ -54,7 +55,7 @@ End legacy CSS
 
 .pricing-cards .cards-container {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(var(--card-width), calc((1200px - 32px) / 3)));
+  grid-template-columns: repeat(auto-fit, minmax(var(--card-width), var(--card-max-width)));
   grid-template-rows: repeat(auto-fit, minmax(311px, 1fr));
   justify-content: center;
   gap: 16px;
@@ -531,6 +532,12 @@ End border style variants
   max-width: 1200px;
   box-sizing: border-box;
   text-align: center;
+}
+
+@media (max-width: 360px) {
+  .pricing-cards .cards-container {
+    grid-template-columns: repeat(auto-fit, minmax(auto, var(--card-max-width)));
+  }
 }
 
 @media (min-width: 768px) and (max-width: 1279px) {


### PR DESCRIPTION
- Fixes card width so content isn't cut off for devices smaller than 360px wide.
- Added a new breakpoint targeting device screens smaller than 360px wide.

Resolves: [MWPW-165757](https://jira.corp.adobe.com/browse/MWPW-165757)

**Test URLs:**
- Before: https://main--express-milo--adobecom.hlx.page/express/pricing?martech=off
- After: https://a11y-pricing-cards-cut-off--express-milo--adobecom.hlx.page/express/pricing?martech=off


![image](https://github.com/user-attachments/assets/279d102b-10ab-4c6d-8108-25e3e173f4a4)
