### PR TITLE
MWPW-164899 - Adjust color for copy to clipboard tooltip

### DIFF
--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2137,7 +2137,7 @@ main .template-x.horizontal > .template-x.horizontal.tabbed > .template-title {
   align-items: center;
   gap: 4px;
   width: 130px;
-  background-color: #33AB84;
+  background-color: var(--background-positive-default);
   color: white;
   text-align: center;
   border-radius: 6px;
@@ -2178,13 +2178,13 @@ main .template-x.horizontal > .template-x.horizontal.tabbed > .template-title {
   margin-top: -5px;
   border-width: 5px;
   border-style: solid;
-  border-color: transparent #33AB84 transparent transparent;
+  border-color: transparent var(--background-positive-default) transparent transparent;
 }
 
 .template-x.horizontal .template:nth-last-of-type(2) .button-container .media-wrapper .share-icon-wrapper .shared-tooltip::after {
   right: unset;
   left: 100%;
-  border-color: transparent transparent transparent #33AB84;
+  border-color: transparent transparent transparent var(--background-positive-default);
 }
 
 .template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip.flipped::after {

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -37,6 +37,7 @@
   --gradient-highlight-diagonal: linear-gradient(45deg, #7c84fc, #ff4dd2);
   --palette-indigo-200: #E0E2FF;
   --palette-indigo-1000: #4046CA;
+  --background-positive-default: #007A4D;
 
   /* header */
   --header-height: 65px;


### PR DESCRIPTION
Updating background color for the copy to clipboard tooltip to meet color contrast accessibility requirements.


Resolves: [MWPW-164899](https://jira.corp.adobe.com/browse/MWPW-164899)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/fragments/homepage-desktop?martech=off
- After: https://a11y-templatex-ctc-contrast--express-milo--adobecom.hlx.page/express/fragments/homepage-desktop?martech=off

<img width="485" alt="image" src="https://github.com/user-attachments/assets/53806260-f6ae-49ff-a2f6-fba2e9d6e594" />
