### PR TITLE
Secondary Button Contrast Ratio

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -325,7 +325,7 @@ main a.button.secondary:any-link:active {
 }
 
 main a.button.secondary:focus{
-  background-color: var(--color-gray-500);
+  background-color: var(--color-gray-700);
   border-color: var(--color-gray-500);
   color: var(--color-white);
 }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -716,12 +716,8 @@ main .section:not(.xxxl-spacing-static,
   padding-bottom: 40px;
 }
 
-main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner) a.button.same-fcta,
-main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner) a.con-button.same-fcta,
-#hero a.same-fcta {
-  display: none;
-}
-
+main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.button.same-fcta,
+main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.con-button.same-fcta,
 /* Store icons */
 main  img.icon-apple-store,
 main  img.icon-google-store,

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -716,8 +716,8 @@ main .section:not(.xxxl-spacing-static,
   padding-bottom: 40px;
 }
 
-main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.button.same-fcta,
-main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.con-button.same-fcta,
+main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner) a.button.same-fcta,
+main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner) a.con-button.same-fcta,
 #hero a.same-fcta {
   display: none;
 }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -718,6 +718,10 @@ main .section:not(.xxxl-spacing-static,
 
 main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.button.same-fcta,
 main .section > div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content) a.con-button.same-fcta,
+#hero a.same-fcta {
+  display: none;
+}
+
 /* Store icons */
 main  img.icon-apple-store,
 main  img.icon-google-store,


### PR DESCRIPTION
Describe your specific features or fixes

Changes the default background color for hovered secondary buttons to gray-700 for better contrast.

Resolves:  https://jira.corp.adobe.com/browse/DOTCOM-129437

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://pricing-card-contrast-ratio--express-milo--adobecom.aem.page/express/pricing
- 
<img width="613" alt="Screenshot 2025-02-04 at 1 18 49 PM" src="https://github.com/user-attachments/assets/9c9504ac-a255-4e17-995c-2294f3c276a2" />

