### PR TITLE
MWPW-164904 - Wayfinder buttons not associated with text

### DIFF
--- a/express/code/blocks/wayfinder/wayfinder.js
+++ b/express/code/blocks/wayfinder/wayfinder.js
@@ -1,8 +1,12 @@
 export default function decorate(el) {
   const rows = el.querySelectorAll(':scope > div');
+  const firstRowContent = rows[0].textContent.trim();
   rows[0].classList.add('text-row');
   rows[1].classList.add('cta-row');
+  rows[1].setAttribute('role', 'group');
+  rows[1].setAttribute('aria-label', firstRowContent);
   rows[1].querySelectorAll('a').forEach((a) => {
     a.classList.add('button');
+    a.setAttribute('role', 'button');
   });
 }


### PR DESCRIPTION
- Added `role=group` buttons container
- Added `aria-label `to buttons container that associates the Wayfinder text to the buttons

Screen readers should now say "Discover quick and easy... grouping Teams button".

Resolves: [MWPW-164904](https://jira.corp.adobe.com/browse/MWPW-164904)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/mep-playground/entitled-home?martech=off
- After: https://a11y-wayfinder-controls--express-milo--adobecom.hlx.page/express/experiments/mep-playground/entitled-home?martech=off
