### PR TITLE
MWPW-164896 - Fix toggle bar to be semantic markup

### DIFF
--- a/express/code/blocks/toggle-bar/toggle-bar.css
+++ b/express/code/blocks/toggle-bar/toggle-bar.css
@@ -89,6 +89,7 @@
 }
 
 .section .toggle-bar-wrapper > .toggle-bar ul {
+    list-style: none;
     padding: 0;
     margin: 0;
     height: 100%;

--- a/express/code/blocks/toggle-bar/toggle-bar.js
+++ b/express/code/blocks/toggle-bar/toggle-bar.js
@@ -4,6 +4,7 @@ import { sendEventToAnalytics, textToName } from '../../scripts/instrument.js';
 let createTag;
 
 function decorateButton(block, toggle) {
+  const li = createTag('li');
   const button = createTag('button', { class: 'toggle-bar-button' });
   const iconsWrapper = createTag('div', { class: 'icons-wrapper' });
   const textWrapper = createTag('div', { class: 'text-wrapper' });
@@ -30,7 +31,8 @@ function decorateButton(block, toggle) {
   }
 
   button.append(iconsWrapper, textWrapper);
-  toggle.parentNode.replaceChild(button, toggle);
+  li.append(button);
+  toggle.parentNode.replaceChild(li, toggle);
 
   let texts = [];
   let child = textWrapper.firstChild;


### PR DESCRIPTION
Fixes the toggle bar list DOM structure to to be accessiable/semantically correct.

 `<ul>` and `<ol>` must only directly contain `<li>`, `<script>` or `<template>` elements

Resolves: [MWPW-164896](https://jira.corp.adobe.com/browse/MWPW-164896)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/mep-playground/entitled-home?martech=off
- After: https://a11y-toggle-bar-semantics--express-milo--adobecom.hlx.page/express/experiments/mep-playground/entitled-home?martech=off


![image](https://github.com/user-attachments/assets/90fcb610-ad32-4512-b879-6c66d434adae)
