### PR TITLE
Aria live template copy

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -106,7 +106,7 @@ async function getVideoUrls(renditionLinkHref, componentLinkHref, page) {
   }
 }
 
-async function share(branchUrl, tooltip, timeoutId, liveRegion,text) {
+async function share(branchUrl, tooltip, timeoutId, liveRegion, text) {
   const urlWithTracking = await getTrackingAppendedURL(branchUrl, {
     placement: 'template-x',
     isSearchOverride: true,
@@ -141,7 +141,7 @@ function renderShareWrapper(branchUrl) {
   });
   const liveRegion = createTag('div', {
     'aria-live': 'polite',
-    'class': 'sr-only',
+    class: 'sr-only',
   });
   wrapper.append(liveRegion);
 

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -106,7 +106,7 @@ async function getVideoUrls(renditionLinkHref, componentLinkHref, page) {
   }
 }
 
-async function share(branchUrl, tooltip, timeoutId) {
+async function share(branchUrl, tooltip, timeoutId, liveRegion,text) {
   const urlWithTracking = await getTrackingAppendedURL(branchUrl, {
     placement: 'template-x',
     isSearchOverride: true,
@@ -119,7 +119,8 @@ async function share(branchUrl, tooltip, timeoutId) {
   if (tooltipRightEdgePos > window.innerWidth) {
     tooltip.classList.add('flipped');
   }
-
+  // Update ARIA-live region
+  liveRegion.textContent = text;
   clearTimeout(timeoutId);
   return setTimeout(() => {
     tooltip.classList.remove('display-tooltip');
@@ -138,18 +139,21 @@ function renderShareWrapper(branchUrl) {
     role: 'tooltip',
     tabindex: '-1',
   });
+  const liveRegion = createTag('div', {
+    'aria-live': 'polite',
+    'class': 'sr-only',
+  });
+  wrapper.append(liveRegion);
+
   let timeoutId = null;
-  shareIcon.addEventListener('click', (ev) => {
+  shareIcon.addEventListener('click', async (ev) => {
     ev.preventDefault();
     ev.stopPropagation();
-    timeoutId = share(branchUrl, tooltip, timeoutId);
+    timeoutId = await share(branchUrl, tooltip, timeoutId, liveRegion, text);
   });
-
-  shareIcon.addEventListener('keypress', (e) => {
-    if (e.key !== 'Enter') {
-      return;
-    }
-    timeoutId = share(branchUrl, tooltip, timeoutId);
+  shareIcon.addEventListener('keypress', async (e) => {
+    if (e.key !== 'Enter') return;
+    timeoutId = await share(branchUrl, tooltip, timeoutId, liveRegion, text);
   });
   const checkmarkIcon = getIconElementDeprecated('checkmark-green');
   tooltip.append(checkmarkIcon);

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2869,7 +2869,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
 }
 
 
-.sr-only {
+.template .sr-only {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2867,3 +2867,15 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     padding-top: 0;
   }
 }
+
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
Describe your specific features or fixes

Implements an aria live region for the share arrow of our template cards.

Resolves: https://jira.corp.adobe.com/browse/MWPW-164900

Visit the template page and use the keyboard to navigate to one of the them while the screen reader is active. Use the Enter button to active the share button.

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/templates/?martech=off
- After: https://aria-live-template-copy--express-milo--adobecom.hlx.page/express/templates/?martech=off
