### PR TITLE
z-index hotfix

### DIFF
--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
@@ -1,5 +1,5 @@
 main  .floating-button-wrapper.mobile-fork-button-frictionless, main .mobile-fork-button-frictionless {
-    z-index: 10;
+    z-index: 8;
     --mfb-font-size: 16px;
 }
 


### PR DESCRIPTION
Additional z-index fix to hide mobile fork when new feds mobile expanded

Resolves: [MWPW-166945](https://jira.corp.adobe.com/browse/MWPW-166945)

Test URLs:

Before: https://main--express-milo--adobecom.aem.page/express/feature/image/remove-backgroundmartech=off&newNav=true
After: https://z-index-hotfix--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off&newNav=true