### PR TITLE
CTA Carousel Cards Update

### DIFF
--- a/express/code/blocks/cta-carousel/cta-carousel.js
+++ b/express/code/blocks/cta-carousel/cta-carousel.js
@@ -141,7 +141,7 @@ async function decorateCards(block, payload) {
 
     cardSleeve.append(mediaWrapper, linksWrapper);
     card.append(cardSleeve, textWrapper);
-
+    card.setAttribute('aria-label', cta.text);
     if (cta.image) mediaWrapper.append(cta.image);
 
     if (cta.videoLink) {


### PR DESCRIPTION
Describe your specific features or fixes

Adds aria-label to the cta carousel cards so that the screen reader conveys the header of the card to the user. 

Resolves:  https://jira.corp.adobe.com/browse/MWPW-164897

Test URLs:
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/ccx0199/premium-discovery-control?martech=off
- After: https://cta-carousel-accessible-link--express-milo--adobecom.hlx.page/express/experiments/ccx0199/premium-discovery-control?martech=off
