### PR TITLE
 Fullscreen Marquee Block Changes for JP LongForm Milo

### DIFF
--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -24,6 +24,7 @@
 
 .fullscreen-marquee .fullscreen-marquee-heading h1 {
   font-size: var(--heading-font-size-l);
+  line-height: 48px;
   text-align: left;
   margin: 0;
 }
@@ -286,6 +287,7 @@
   
   .fullscreen-marquee.longform .fullscreen-marquee-heading h1 {
     font-size: var(--heading-font-size-xl);
+    line-height: 58px;
   }
 
   .fullscreen-marquee .fullscreen-marquee-heading h1 {

--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -279,6 +279,10 @@
     max-width: 1160px;
     text-align: center;
   }
+
+  .fullscreen-marquee.longform .fullscreen-marquee-heading {
+    max-width: 916px;
+  }
   
   .fullscreen-marquee.longform .fullscreen-marquee-heading h1 {
     font-size: var(--heading-font-size-xl);

--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -281,7 +281,7 @@
   }
   
   .fullscreen-marquee.longform .fullscreen-marquee-heading h1 {
-    font-size: 45px;
+    font-size: var(--heading-font-size-xl);
   }
 
   .fullscreen-marquee .fullscreen-marquee-heading h1 {

--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -279,6 +279,10 @@
     max-width: 1160px;
     text-align: center;
   }
+  
+  .fullscreen-marquee.longform .fullscreen-marquee-heading h1 {
+    font-size: 45px;
+  }
 
   .fullscreen-marquee .fullscreen-marquee-heading h1 {
     font-size: 80px;


### PR DESCRIPTION
 Fullscreen Marquee Block Changes for JP LongForm Milo:
* Reduces desktop font-size to 45px from 80px

Resolves: [MWPW-167469](https://jira.corp.adobe.com/browse/MWPW-167469)

Test URLs:
- After: https://jp-longform-fullscreen-marquee--express-milo--adobecom.hlx.page/drafts/jsandlan/milo-long-form-fullscreen-marquee?martech=off
<img width="791" alt="mobile-fs-marquee" src="https://github.com/user-attachments/assets/29374ac1-9e80-4101-80ee-e28073b2a0ed" />
<img width="1368" alt="desktop-fs-marquee" src="https://github.com/user-attachments/assets/f78f567a-2688-4b7a-ad80-0ae0f18cb5f0" />

