### PR TITLE
JP Text Content Left Aligns By Default + Authoring Ability To Center Text

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -699,11 +699,11 @@ main .section > .content {
   max-width: 375px;
 }
 
-:lang(jp) main .section > .content  {
+:lang(ja) main .section > .content  {
   text-align: left;
 }
 
-:lang(jp) main .section > .content.center  {
+:lang(ja) main .section > .content.center  {
   text-align: center;
 }
 

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -177,10 +177,10 @@ main a, main a:hover, main u {
   text-decoration: none;
 }
 
-:lang(en) main .section > .content  {
+:lang(jp) main .section > .content  {
   text-align: left;
 }
-:lang(en) main .section > .content.center  {
+:lang(jp) main .section > .content.center  {
   text-align: center;
 }
 

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -177,13 +177,6 @@ main a, main a:hover, main u {
   text-decoration: none;
 }
 
-:lang(jp) main .section > .content  {
-  text-align: left;
-}
-:lang(jp) main .section > .content.center  {
-  text-align: center;
-}
-
 main video {
   max-width: 100%;
 }
@@ -704,6 +697,14 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
 main .section > .content {
   text-align: center;
   max-width: 375px;
+}
+
+:lang(jp) main .section > .content  {
+  text-align: left;
+}
+
+:lang(jp) main .section > .content.center  {
+  text-align: center;
 }
 
 main .section .content p, main .section p {

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -177,6 +177,13 @@ main a, main a:hover, main u {
   text-decoration: none;
 }
 
+:lang(en) main .section > .content  {
+  text-align: left;
+}
+:lang(en) main .section > .content.center  {
+  text-align: center;
+}
+
 main video {
   max-width: 100%;
 }


### PR DESCRIPTION
Describe your specific features or fixes:
* Default left-aligns text content on JP pages
* Allows authors to use center class to center text

Resolves: [MWPW-167482](https://jira.corp.adobe.com/browse/MWPW-167482)

Test URLs:
- After: https://jp-longform-text-content--express-milo--adobecom.hlx.page/jp/drafts/milo-long-form-text-content?martech=off
