### PR TITLE
MWPW-164903 - Play/pause tooltip included in hover hit area

### DIFF
--- a/express/code/blocks/ax-marquee/ax-marquee.css
+++ b/express/code/blocks/ax-marquee/ax-marquee.css
@@ -250,17 +250,14 @@ body.no-desktop-brand-header header {
     bottom: 16px;
     height: 24px;
     cursor: pointer;
+    display: flex;
+    gap: 8px;
 }
 
 .ax-marquee .reduce-motion-wrapper span {
-    position: absolute;
-    margin-right: 8px;
-    right: 100%;
-    top: 50%;
-    transform: translateY(-50%);
-    visibility: hidden;
+    display: none;
     opacity: 0;
-    transition: visibility 0s, opacity 0.3s;
+    animation: fadeIn 0.3s;
     pointer-events: none;
 }
 
@@ -283,6 +280,19 @@ body.no-desktop-brand-header header {
 .ax-marquee:not(.reduce-motion) .reduce-motion-wrapper:hover span.pause-animation-text {
     opacity: 1;
     visibility: visible;
+    display: block;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    display: none;
+  }
+  
+  to {
+    opacity: 1;
+    display: block;
+  }
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
- Allow the user to move the mouse pointer over the play/pause tooltip without the tooltip disappearing.


**Context:**
Accessibility requirement:
The animation play/pause icon tooltip MUST allow the user to move the mouse pointer over without the tooltip disappearing.

Resolves: [MWPW-164903](https://jira.corp.adobe.com/browse/MWPW-164903)

Test URLs:
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/ccx0199/premium-discovery-control?martech=off
- After: https://a11y-play-pause-hover--express-milo--adobecom.hlx.page/express/experiments/ccx0199/premium-discovery-control?martech=off


**Testing notes:**
Mouse over the play/pause icon in the marquee. You should now beable to mouse over the tooltip (play animation) with out the tooltip disappearing. 