### PR TITLE
Ensure Blog Page Content Aligns With Figma

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -697,15 +697,6 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
   margin-right: 4px;
 }
 
-main .section.left > .content > * { 
-  text-align: left;
-}
-
-main .section.left > .content > p {
-  margin: 20px;
-  font-size: var(--body-font-size-m);
-}
-
 main .section > .content {
   text-align: center;
   max-width: 375px;
@@ -784,11 +775,20 @@ main :lang(ja) h2.heading-x-long, main :lang(ja) #hero h2.heading-x-long {
   font-size: var(--heading-font-size-m);
 }
 
-@media (min-width: 400px) {
-  main .section.left > .content > p {
-    margin: auto;
-    font-size: 20px;
-  }
+
+main .section.left > .content *:is(h1, h2) {
+  font-size: 32px;
+}
+
+main .section.left > .content *:is(h1, h2, h3, h4, h5, h6),
+main .section.left > .content > p  {
+  margin-left: 20px;
+  margin-right: 20px;
+  text-align: left;
+}
+
+main .section.left > .content > p {
+  font-size: var(--body-font-size-m);
 }
 
 @media (min-width: 600px) {
@@ -832,10 +832,11 @@ main :lang(ja) h2.heading-x-long, main :lang(ja) #hero h2.heading-x-long {
   }
 
   main .section.left > .content {
-    margin: auto;
-    padding-left: 20px;
-    padding-right: 20px;
     max-width: 648px
+  }
+  
+  main .section.left > .content > p {
+    font-size: var(--body-font-size-xl);
   }
 }
 
@@ -898,6 +899,12 @@ main :lang(ja) h2.heading-x-long, main :lang(ja) #hero h2.heading-x-long {
 
   main .section > .content {
     max-width: 830px;
+  }
+
+  main .section.left > .content *:is(h1, h2, h3, h4, h5, h6),
+  main .section.left > .content > p  {
+    margin-left: unset;
+    margin-right: unset;
   }
 }
 

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -697,9 +697,13 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
   margin-right: 4px;
 }
 
-main .section.left > .content {
+main .section.left > .content > * { 
   text-align: left;
+}
+
+main .section.left > .content > p {
   margin: 20px;
+  font-size: var(--body-font-size-m);
 }
 
 main .section > .content {
@@ -780,6 +784,13 @@ main :lang(ja) h2.heading-x-long, main :lang(ja) #hero h2.heading-x-long {
   font-size: var(--heading-font-size-m);
 }
 
+@media (min-width: 400px) {
+  main .section.left > .content > p {
+    margin: auto;
+    font-size: 20px;
+  }
+}
+
 @media (min-width: 600px) {
   main h2 {
     font-size: var(--heading-font-size-l);
@@ -818,6 +829,13 @@ main :lang(ja) h2.heading-x-long, main :lang(ja) #hero h2.heading-x-long {
     line-height: var(--body-line-height);
     text-align: center;
     margin: 24px 15px 0;
+  }
+
+  main .section.left > .content {
+    margin: auto;
+    padding-left: 20px;
+    padding-right: 20px;
+    max-width: 648px
   }
 }
 

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -776,18 +776,18 @@ main :lang(ja) h2.heading-x-long, main :lang(ja) #hero h2.heading-x-long {
 }
 
 
-main .section.left > .content *:is(h1, h2) {
+main .section.blog-content > .content *:is(h1, h2) {
   font-size: 32px;
 }
 
-main .section.left > .content *:is(h1, h2, h3, h4, h5, h6),
-main .section.left > .content > p  {
+main .section.blog-content > .content *:is(h1, h2, h3, h4, h5, h6),
+main .section.blog-content > .content > p  {
   margin-left: 20px;
   margin-right: 20px;
   text-align: left;
 }
 
-main .section.left > .content > p {
+main .section.blog-content > .content > p {
   font-size: var(--body-font-size-m);
 }
 
@@ -831,11 +831,11 @@ main .section.left > .content > p {
     margin: 24px 15px 0;
   }
 
-  main .section.left > .content {
+  main .section.blog-content > .content {
     max-width: 648px
   }
   
-  main .section.left > .content > p {
+  main .section.blog-content > .content > p {
     font-size: var(--body-font-size-xl);
   }
 }
@@ -901,8 +901,8 @@ main .section.left > .content > p {
     max-width: 830px;
   }
 
-  main .section.left > .content *:is(h1, h2, h3, h4, h5, h6),
-  main .section.left > .content > p  {
+  main .section.blog-content > .content *:is(h1, h2, h3, h4, h5, h6),
+  main .section.blog-content > .content > p  {
     margin-left: unset;
     margin-right: unset;
   }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -697,6 +697,11 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
   margin-right: 4px;
 }
 
+main .section.left > .content {
+  text-align: left;
+  margin: 20px;
+}
+
 main .section > .content {
   text-align: center;
   max-width: 375px;


### PR DESCRIPTION
**Ensure Blog Page Content Aligns With Figma** 

Describe your specific features or fixes:
* Allow Left Alignment of Content
* Ensure Font Size is 20px on desktop / 16px on mobile
* Ensure Max Width set to 648px on Desktop
* Ensure space exists on either side of content on mobile viewports

Resolves: [MWPW-167568](https://jira.corp.adobe.com/browse/MWPW-167568)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://milo-blog--express-milo--adobecom.hlx.page/drafts/jsandlan/milo-blog?martech=off
