### PR TITLE
Fix For Pricing Table Wrapper

### DIFF
--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -778,7 +778,10 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     font-weight: 900;
     font-size: 18px;
   }
-  
+  main .section .pricing-table-wrapper:has(.pricing-table.seamless){
+    max-width: 1100px;
+  }
+
   .pricing-table.seamless {
     width: 1100px;
   }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -178,18 +178,17 @@
 }
 
 /* Table Width */
-main .section .pricing-table {
+main .section .pricing-table-wrapper {
   margin: auto;
   max-width: 900px;
 }
-main .section .pricing-table:has(.pricing-table.few-cols) {
+main .section .pricing-table-wrapper:has(.pricing-table.few-cols) {
   max-width: 700px;
 }
-main .section .pricing-table:has(.pricing-table.many-cols) {
+main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   max-width: 1200px;
 } 
 /* /Table Width */
-
 .pricing-table .row:not(.blank-row) {
   min-height: 80px;
 }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -712,7 +712,8 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     font-size: 18px;
   }
   
-  .pricing-table .row.row-heading .col > div p {
+  .pricing-table .row.row-heading .col > div p,
+  .pricing-table .row.row-heading .col > div p strong {
     font-weight: 900;
     font-size: 18px;
   }
@@ -730,8 +731,11 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
    border-bottom-left-radius: 0px;
    border-bottom-right-radius: 0px;
    border-top: none;
-  } 
-
+  }
+  .pricing-table.seamless .row-1 .col-1 p {
+  margin-top: auto;
+  padding-bottom: 10px;
+  }
   .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col-1 {
     border-left: none;
     border-top: none;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -789,6 +789,10 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     color:  #505050;
   }
 
+  .pricing-table.seamless  .row-1 .col {
+    padding: 24px;
+  }
+
   .pricing-table.seamless .row-2{
     height: 0px;
   } 
@@ -799,11 +803,17 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   .pricing-table.seamless .row-4 div:last-child{
     border-top-right-radius: 8px;
   } 
+
   .pricing-table.seamless .row-1 .col {
     border-bottom: none;
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
     border-top: none;
+   
+  }
+
+  .pricing-table.seamless.vertical-header .row-1 .col div {
+    row-gap: 8px;
   }
 
   .pricing-table.seamless .row-1 .col:nth-child(2n) {
@@ -813,7 +823,6 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 
   .pricing-table.seamless .row-1 .col-1 p {
     margin-top: auto;
-    padding-bottom: 10px;
   }
   
   .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col-1 {
@@ -829,4 +838,28 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   .pricing-table.seamless .row-3 {
     display: none;
   }  
+
+  .pricing-table.seamless .table-end-row:last-of-type{
+    border-bottom: var(--border-width) solid var(--border-color);
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+  } 
+
+  .pricing-table.seamless .table-end-row:last-of-type .col-1 {
+    border-bottom-left-radius: 8px;
+  }
+
+  .pricing-table.seamless .table-end-row:last-of-type .col:last-child {
+    border-bottom-right-radius: 8px;
+  }
+
+  .pricing-table.seamless .toggle-row {
+    min-height: 5px;
+    height: 5px;
+    padding: 0;
+    display: none;
+  }
+  .pricing-table.seamless .toggle-content{
+    display: none !important;
+  }
 }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -727,15 +727,17 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   } 
 
   .pricing-table.seamless .row-1 .col {
-   border-bottom: none;
-   border-bottom-left-radius: 0px;
-   border-bottom-right-radius: 0px;
-   border-top: none;
+    border-bottom: none;
+    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px;
+    border-top: none;
   }
+
   .pricing-table.seamless .row-1 .col-1 p {
-  margin-top: auto;
-  padding-bottom: 10px;
+    margin-top: auto;
+    padding-bottom: 10px;
   }
+  
   .pricing-table.seamless .table-end-row:not(.connect-to-toggle).row:first-of-type .col-1 {
     border-left: none;
     border-top: none;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -787,6 +787,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   .pricing-table.seamless {
     width: 1100px;
     color:  #505050;
+    padding-bottom: 0px;
   }
 
   .pricing-table.seamless  .row-1 .col {
@@ -809,6 +810,15 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
     border-top: none;
+   
+  }
+
+  .pricing-table.seamless .col.dim .col-content .icon-container:after {
+    background: var(--Background-Positive-subdued, #CEF8E0);
+  }
+  .pricing-table.seamless .dim .col-content span {
+    color: var(--checkmark-color);
+    background-color:  var(--checkmark-color);
    
   }
 

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -370,7 +370,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 .pricing-table.vertical-header .row.row-heading .col > div {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
 }
 
 .pricing-table .row.row-heading .col .buttons-wrapper {
@@ -777,6 +777,8 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   .pricing-table .row.row-heading .col > div p strong {
     font-weight: 900;
     font-size: 18px;
+    font-family: 'adobe-clean';
+    color: black;
   }
   main .section .pricing-table-wrapper:has(.pricing-table.seamless){
     max-width: 1100px;
@@ -784,17 +786,29 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 
   .pricing-table.seamless {
     width: 1100px;
+    color:  #505050;
   }
 
   .pricing-table.seamless .row-2{
     height: 0px;
   } 
 
+  .pricing-table.seamless .row-4 .col-1{
+    border-top-left-radius: 8px;
+  } 
+  .pricing-table.seamless .row-4 div:last-child{
+    border-top-right-radius: 8px;
+  } 
   .pricing-table.seamless .row-1 .col {
     border-bottom: none;
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
     border-top: none;
+  }
+
+  .pricing-table.seamless .row-1 .col:nth-child(2n) {
+    border-top-right-radius: 16px;
+    border-top-left-radius: 16px;
   }
 
   .pricing-table.seamless .row-1 .col-1 p {

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -821,11 +821,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
     background-color:  var(--checkmark-color);
    
   }
-
-  .pricing-table.seamless.vertical-header .row-1 .col div {
-    row-gap: 8px;
-  }
-
+  
   .pricing-table.seamless .row-1 .col:nth-child(2n) {
     border-top-right-radius: 16px;
     border-top-left-radius: 16px;

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -59,7 +59,6 @@ function handleHeading(headingRow, headingCols) {
     if (buttons.length > 0) {
       col.append(buttonsWrapper);
     }
-   
 
     if (buttons.length > 1) {
       buttons.forEach((btn, index) => {

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -56,7 +56,10 @@ function handleHeading(headingRow, headingCols) {
       btnWrapper.classList.add('button-container');
       buttonsWrapper.append(btnWrapper);
     });
-    col.append(buttonsWrapper);
+    if (buttons.length > 0) {
+      col.append(buttonsWrapper);
+    }
+   
 
     if (buttons.length > 1) {
       buttons.forEach((btn, index) => {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -513,6 +513,10 @@ main .section>.simplified-pricing-cards-wrapper {
         gap: 8px;
     }
 
+    .simplified-pricing-cards.wide {
+        --card-width: 385px;
+    }
+
     .simplified-pricing-cards .toggle-switch-wrapper {
         display: none;
     }


### PR DESCRIPTION
Describe your specific features or fixes

Restores the pricing table wrapper CSS to ensure the table is the correct width on desktop resolutions.

Fixed issue with the bold CSS for the header not appearing. 

Implements a `seamless` variant of the pricing table that matches the design for the new business hub.

Implements a `wide` variant for the simplified pricing cards to make it 400 px wide on desktop if desired by authors.

Refactors the media query cutoffs for the pricing table.

<img width="1055" alt="Screenshot 2025-01-31 at 4 14 23 PM" src="https://github.com/user-attachments/assets/645b33b8-b731-4d87-a12b-1c03df6d76de" />

<img width="1742" alt="Screenshot 2025-02-07 at 9 38 24 AM" src="https://github.com/user-attachments/assets/4e454517-a036-4d77-8555-be93456b22ad" />


Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-166366
https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-166368

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before:https://main--express-milo--adobecom.hlx.page/drafts/echen/individuals-and-teams-upgrade?martech=off
- https://main--express-milo--adobecom.hlx.page/express/pricing?martech=off
- After: https://pricing-table-wrapper-fix--express-milo--adobecom.hlx.page/drafts/echen/individuals-and-teams-upgrade?martech=off
 - https://pricing-table-wrapper-fix--express-milo--adobecom.hlx.page/express/pricing?martech=off
