### PR TITLE
JP Text Content Left Aligns By Default + Authoring Ability To Center Text 2

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -697,6 +697,14 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
   margin-right: 4px;
 }
 
+:lang(ja) main .section > .content  {
+  text-align: left;
+}
+
+:lang(ja) main .section > .content.center  {
+  text-align: center;
+}
+
 main .section > .content {
   text-align: center;
   max-width: 375px;


### PR DESCRIPTION
Describe your specific features or fixes:

Default left-aligns text content on JP pages
Allows authors to use center class to center text
Resolves: [MWPW-167482](https://jira.corp.adobe.com/browse/MWPW-167482)

Test URLs:

After: https://jp-longform-text-content-2--express-milo--adobecom.hlx.page/jp/drafts/milo-long-form-text-content?martech=off