### PR TITLE
Promotions Block Changes for JP LongForm Milo 2

### DIFF
--- a/express/code/blocks/promotion/promotion.css
+++ b/express/code/blocks/promotion/promotion.css
@@ -51,9 +51,19 @@
   margin-top: 0;
 }
 
-.promotion.narrow {
-  max-width: 850px;
-  margin: 0 auto;
+.promotion.longform {
+  margin: 10px 10px 100px;
+}
+
+.promotion.longform .promotion-wrapper {
+  margin-top: 40px;
+}
+
+@media (min-width: 400px) {
+  .promotion.longform {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
Promotions Block Changes for JP LongForm Milo:
* Ensures promotions has margin on sides for small viewports
* Adds margin bottom to ensure space between bottom of block and next element
* Reduces margin-top to bring the header closer to the block

Resolves: [MWPW-167468](https://jira.corp.adobe.com/browse/MWPW-167468)

Test URLs:

After: https://jp-longform-promotions-mobile-2--express-milo--adobecom.hlx.page/drafts/jsandlan/milo-long-form-promotions?martech=off