### PR TITLE
Ensure JP Content Is Padded On Mobile Devices On Left And Right

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -699,10 +699,12 @@ main .free-plan-widget .plan-widget-tag img.icon.icon-checkmark {
 
 :lang(ja) main .section > .content  {
   text-align: left;
+  padding: 60px 20px 0;
 }
 
 :lang(ja) main .section > .content.center  {
   text-align: center;
+  padding: 60px 20px 0;
 }
 
 main .section > .content {


### PR DESCRIPTION
Describe your specific features or fixes:
* Ensures left and right padding exists on mobile devices for jp content text

Resolves: [MWPW-167482](https://jira.corp.adobe.com/browse/MWPW-167482)

Test URLs:
Before: https://jp-longform-text-content-2--express-milo--adobecom.hlx.page/jp/drafts/milo-long-form-text-content?martech=off
After: https://jp-content-padding--express-milo--adobecom.hlx.page/jp/drafts/milo-long-form-text-content?martech=off
