### PR TITLE
MWPW-168115 - Add keyboard navigation to work with play/pause tooltip

### DIFF
--- a/express/code/blocks/ax-marquee/ax-marquee.css
+++ b/express/code/blocks/ax-marquee/ax-marquee.css
@@ -277,10 +277,17 @@ body.no-desktop-brand-header header {
 }
 
 .ax-marquee.reduce-motion .reduce-motion-wrapper:hover span.play-animation-text,
-.ax-marquee:not(.reduce-motion) .reduce-motion-wrapper:hover span.pause-animation-text {
+.ax-marquee:not(.reduce-motion) .reduce-motion-wrapper:hover span.pause-animation-text,
+.ax-marquee.reduce-motion .reduce-motion-wrapper:focus-visible span.play-animation-text,
+.ax-marquee:not(.reduce-motion) .reduce-motion-wrapper:focus-visible span.pause-animation-text {
     opacity: 1;
     visibility: visible;
     display: block;
+}
+
+.ax-marquee.reduce-motion .reduce-motion-wrapper:focus-visible span.play-animation-text,
+.ax-marquee:not(.reduce-motion) .reduce-motion-wrapper:focus-visible span.pause-animation-text {
+  margin-left: 5px;
 }
 
 @keyframes fadeIn {

--- a/express/code/blocks/ax-marquee/ax-marquee.js
+++ b/express/code/blocks/ax-marquee/ax-marquee.js
@@ -182,10 +182,14 @@ async function buildReduceMotionSwitch(block, marqueeForeground) {
         }
       }
     }
+    // Initialize toggle content for accessibility
+    decorateToggleContext(reduceMotionIconWrapper);
+
     reduceMotionIconWrapper.addEventListener(
       'keydown',
       async (e) => {
         if (!e.target.isEqualNode(document.activeElement)) return;
+        if (e.code === 'Escape') reduceMotionIconWrapper.blur();
         if (e.code !== 'Space' && e.code !== 'Enter') return;
         e.preventDefault();
         handlePause(block, e.currentTarget);
@@ -196,13 +200,6 @@ async function buildReduceMotionSwitch(block, marqueeForeground) {
       'click',
       async (e) => {
         handlePause(block, e.currentTarget);
-      },
-      { passive: true },
-    );
-    reduceMotionIconWrapper.addEventListener(
-      'mouseenter',
-      (e) => {
-        decorateToggleContext(e.currentTarget);
       },
       { passive: true },
     );


### PR DESCRIPTION
- Tabbing to the play/pause button in a marquee now displays the tooltip - previously the tooltip only showed on hover.
- Pressing the Escape key after tabbing to the play/pause button will hide the tooltip. This works off of the CSS `focus-visible` pseudo selector

**Context:**
A keyboard user has to be able to see the tooltip on focus too. And then be able to escape to close the tooltip.

Resolves: [MWPW-168115](MWPW-URL)

**Test URLs:**
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/ccx0199/premium-discovery-control?martech=off
- After: https://a11y-keyboard-navigation-play-pause--express-milo--adobecom.hlx.page/express/experiments/ccx0199/premium-discovery-control?martech=off

**Testing notes:**
Using your keyboard, tab to the play/pause button in the marquee. The tooltip should display when that button has focus. Previously the tooltip only showed on hover.

Keyboard navigation - pressing the escape key while the play/pause button is in focus will remove focus and hide the tooltip.