### PR TITLE
[MWPW-167968] Remove Android RAM check from checking Frictionless eligibility

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -75,10 +75,6 @@ function selectElementByTagPrefix(p) {
   return Array.from(allEls).find((e) => e.tagName.toLowerCase().startsWith(p.toLowerCase()));
 }
 
-function isEligibleMFQA() {
-  return navigator.deviceMemory >= 4 && getMobileOperatingSystem() === 'Android';
-}
-
 export function runQuickAction(quickAction, data, block) {
   // TODO: need the button labels from the placeholders sheet if the SDK default doens't work.
   const exportConfig = [
@@ -303,7 +299,7 @@ export default async function decorate(block) {
   quickActionRow?.remove();
   const [fallbackRow] = rows.filter((row) => row.children[0]?.textContent?.toLowerCase()?.trim() === 'fallback');
   fallbackRow?.remove();
-  if (fallbackRow && !isEligibleMFQA()) {
+  if (fallbackRow && getMobileOperatingSystem() !== 'Android') {
     const fallbackBlock = fallbackRow.querySelector(':scope > div:last-child > div');
     block.replaceWith(fallbackBlock);
     return fallbackBlock;

--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -41,12 +41,6 @@ export async function createMultiFunctionButton(block, data, audience) {
   return buttonWrapper;
 }
 
-// frictionless block always check eligibility
-function androidDeviceAndRamCheck() {
-  const isAndroid = getMobileOperatingSystem() === 'Android';
-  return navigator.deviceMemory >= 4 && isAndroid;
-}
-
 function collectFloatingButtonData(eligible) {
   const metadataMap = Array.from(document.head.querySelectorAll('meta')).reduce((acc, meta) => {
     if (meta?.name && !meta.property) acc[meta.name] = meta.content || '';
@@ -114,7 +108,7 @@ function collectFloatingButtonData(eligible) {
 }
 
 export default async function decorate(block) {
-  const eligible = androidDeviceAndRamCheck();
+  const eligible = getMobileOperatingSystem() === 'Android';
   addTempWrapperDeprecated(block, 'multifunction-button');
   if (!block.classList.contains('meta-powered')) return;
 

--- a/express/code/blocks/mobile-fork-button/mobile-fork-button.js
+++ b/express/code/blocks/mobile-fork-button/mobile-fork-button.js
@@ -40,13 +40,12 @@ export async function createMultiFunctionButton(block, data, audience) {
   return buttonWrapper;
 }
 
-// Checks if the device is an android and has sufficient RAM, enables the mobile gating if it is.
+// Checks if the device is an android, enables the mobile gating if it is.
 // If there is no metadata check enabled, still enable the gating block in case authors want it.
 
-function androidDeviceAndRamCheck() {
+function androidCheck() {
   if (getMetadata('fork-eligibility-check')?.toLowerCase()?.trim() !== 'on') return true;
-  const isAndroid = getMobileOperatingSystem() === 'Android';
-  return navigator.deviceMemory >= 4 && isAndroid;
+  return getMobileOperatingSystem() === 'Android';
 }
 
 function collectFloatingButtonData() {
@@ -110,7 +109,7 @@ function collectFloatingButtonData() {
 
 export default async function decorate(block) {
   ({ createTag, getMetadata } = await import(`${getLibs()}/utils/utils.js`));
-  if (!androidDeviceAndRamCheck()) {
+  if (!androidCheck()) {
     const { default: decorateNormal } = await import('../floating-button/floating-button.js');
     decorateNormal(block);
     return;


### PR DESCRIPTION
As the web app product now supports all Android devices with RAM>=3GB, we start simplifying our gating logic and treating Android devices with RAM<3GB as edge cases. This allows us to lean closer to personalization setups in other a.com projects and remove express-specific customizations.

Resolves: https://jira.corp.adobe.com/browse/MWPW-167968

Test URLs:
- Before: https://main--express-milo--adobecom.aem.live/express/feature/image/flip?martech=off
- After: https://ram-check-removal--express-milo--adobecom.aem.live/express/feature/image/flip?martech=off

How to test for regression:
- Use any real Android phones or Chrome Dev Tools Emulation with Android devices, you should see the floating panel displaying 2 CTAs
- Use any real iOS phones or Chrome Dev Tools Emulation with iPhones, you should see only 1 colorful floating button

Note:
It's really hard to find an Android phone with 1gb or 2gb RAM (you can't even run functional Android versions with < 2gb), and that population overlapping with AX user groups is even smaller