### PR TITLE
[MWPW-168298] Update SUSI Signin Detection

### DIFF
--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -93,8 +93,8 @@ export default async function init(el) {
   }
   const destURL = getDestURL(redirectUrl);
   const goDest = () => {
-    window.location.assign(destURL);
     sendEventToAnalytics('redirect', 'logged-in-auto-redirect');
+    window.location.assign(destURL);
   };
   if (window.adobeIMS) {
     window.adobeIMS.isSignedInUser() && goDest();

--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -55,28 +55,6 @@ export default async function init(el) {
     client_id,
     scope: 'AdobeID,openid',
   };
-  const destURL = getDestURL(redirectUrl);
-  const goDest = () => window.location.assign(destURL);
-  if (window.adobeIMS) {
-    window.adobeIMS.isSignedInUser() && goDest();
-  } else {
-    loadIms()
-      .then(() => {
-        /* c8 ignore next */
-        window.adobeIMS?.isSignedInUser() && goDest();
-      })
-      .catch((e) => { window.lana?.log(`Unable to load IMS in susi-light: ${e}`); });
-  }
-  el.innerHTML = '';
-  await loadWrapper();
-  const config = { consentProfile: 'free' };
-  if (title) { config.title = title; }
-  const susi = createTag('susi-sentry-light');
-  susi.authParams = authParams;
-  susi.authParams.redirect_uri = destURL;
-  susi.config = config;
-  if (isStage) susi.stage = 'true';
-  susi.variant = variant;
   function sendEventToAnalytics(type, eventName) {
     const sendEvent = () => {
       window._satellite.track('event', {
@@ -113,6 +91,31 @@ export default async function init(el) {
       }, { once: true });
     }
   }
+  const destURL = getDestURL(redirectUrl);
+  const goDest = () => {
+    window.location.assign(destURL);
+    sendEventToAnalytics('redirect', 'logged-in-auto-redirect');
+  };
+  if (window.adobeIMS) {
+    window.adobeIMS.isSignedInUser() && goDest();
+  } else {
+    loadIms()
+      .then(() => {
+        /* c8 ignore next */
+        window.adobeIMS?.isSignedInUser() && goDest();
+      })
+      .catch((e) => { window.lana?.log(`Unable to load IMS in susi-light: ${e}`); });
+  }
+  el.innerHTML = '';
+  await loadWrapper();
+  const config = { consentProfile: 'free' };
+  if (title) { config.title = title; }
+  const susi = createTag('susi-sentry-light');
+  susi.authParams = authParams;
+  susi.authParams.redirect_uri = destURL;
+  susi.config = config;
+  if (isStage) susi.stage = 'true';
+  susi.variant = variant;
 
   const onAnalytics = (e) => {
     const { type, event } = e.detail;


### PR DESCRIPTION
Post migration and the adoption of UNAV, the way to detect whether a user is logged in has changed, and SUSI-Light's feature of auto redirecting logged-in users has stopped working. This PR aims to update the detection method to the latest approach and bring back the auto-redirect feature.

Resolves: https://jira.corp.adobe.com/browse/MWPW-168298

How to test:
- Connect to VPN, and visit stage.adobe.com/express/ to first sign in to stage IMS.
- Visit the test url, and make sure on top right you can see that you're signed in.
- Click the first purple "Sign up for free" CTA, and you should be redirected to the destination right away

Note: had to borrow the jarvis branch since we only have a handful of branch urls usable for testing IMS related stuff

Test URLs:
- Before: https://main--express-milo--adobecom.aem.page/education/express/?martech=off
- After: https://jarvis--express-milo--adobecom.aem.page/education/express/?martech=off
