### PR TITLE
MWPW-164894 Heading Tag Type Change

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -100,7 +100,7 @@
   margin: 0;
 }
 
-.gen-ai-cards .card .text-wrapper p.cta-card-title {
+.gen-ai-cards .card .text-wrapper .cta-card-title {
   font-size: var(--body-font-size-l);
   line-height: var(--body-font-size-m);
   font-weight: 700;

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.js
@@ -166,9 +166,9 @@ async function decorateCards(block, { actions }) {
         a.removeAttribute('title');
         linksWrapper.append(a);
       }
-    }
+    } 
 
-    const titleText = decorateTextWithTag(title, { tagT: 'sup', baseClass: 'cta-card-title' });
+    const titleText = decorateTextWithTag(title, { tagT: 'sup', baseClass: 'cta-card-title', baseT : 'h4' });
     textWrapper.append(titleText);
     const desc = createTag('p', { class: 'cta-card-desc' });
     desc.textContent = text;

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.js
@@ -166,9 +166,9 @@ async function decorateCards(block, { actions }) {
         a.removeAttribute('title');
         linksWrapper.append(a);
       }
-    } 
+    }
 
-    const titleText = decorateTextWithTag(title, { tagT: 'sup', baseClass: 'cta-card-title', baseT : 'h4' });
+    const titleText = decorateTextWithTag(title, { tagT: 'sup', baseClass: 'cta-card-title', baseT: 'h4' });
     textWrapper.append(titleText);
     const desc = createTag('p', { class: 'cta-card-desc' });
     desc.textContent = text;


### PR DESCRIPTION
Describe your specific features or fixes

Changes the header tag in the gen-ai-cards carousel block from `div` to `h4`

Resolves: https://jira.corp.adobe.com/browse/MWPW-164894

Test Instructions:
Visit the after URL below and navigate to the gen ai cards section in the picture. Verify the element is an h4 in the inspector and not a div.

<img width="1448" alt="Screenshot 2025-02-20 at 1 19 30 PM" src="https://github.com/user-attachments/assets/e934d63e-f1db-4346-bc4e-e5d325768a01" />


Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/ccx0167/home
- After: https://heading-accessibility-old-homepage--express-milo--adobecom.hlx.page/express/experiments/ccx0167/home
