### PR TITLE
[DOTCOM-139510] FloatingCTA Error Handling for Invalid Target Links

### DIFF
--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -457,7 +457,12 @@ export function preDecorateSections(area) {
     const textToTarget = getMetadata(`${device}-floating-cta-text`)?.trim() || getMetadata('main-cta-text')?.trim();
     const linkToTarget = getMetadata(`${device}-floating-cta-link`)?.trim() || getMetadata('main-cta-link')?.trim();
     if (textToTarget || linkToTarget) {
-      const linkToTargetURL = new URL(linkToTarget);
+      let linkToTargetURL = null;
+      try {
+        linkToTargetURL = new URL(linkToTarget);
+      } catch (err) {
+        window.lana?.log(err);
+      }
       const sameUrlCTAs = Array.from(area.querySelectorAll('a:any-link'))
         .filter((a) => {
           try {


### PR DESCRIPTION
As of now, when an invalid url is mis-authored for main-cta-link metadata for floatingCTA, an unhandled InvalidURL error will crash the entire page. Although this can be easily discovered fixed before publishing, it can be confusing for authors as the page hangs. This PR aims to still render out the page but log a message. A future work would be to make the authoring error more prominent and easier to understand.

Resolves: https://jira.corp.adobe.com/browse/DOTCOM-139510

Test URLs:
- Before: https://main--express-milo--adobecom.aem.page/drafts/jingle/template-x-still?martech=off
- After: https://fcta-url-try-catch--express-milo--adobecom.aem.page/drafts/jingle/template-x-still?martech=off
