### PR TITLE
MWPW-164913 - Edit this template button accessibility update

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -466,6 +466,7 @@ function renderHoverWrapper(template) {
     ctaLink = renderCTALink(template.customLinks.branchUrl);
   }
 
+  cta.setAttribute('aria-label', `${editThisTemplate}: ${getTemplateTitle(template)}`);
   ctaLink.append(mediaWrapper);
 
   btnContainer.append(cta);


### PR DESCRIPTION
Update "edit this template" button to include aria-label with template name for better accessibility . 
Screen readers will now describe "edit this template" along with the template name. 

Resolves: [MWPW-164913](https://jira.corp.adobe.com/browse/MWPW-164913)

Test URLs:
- Before: https://main--express-milo--adobecom.hlx.page/docs/authoring/template-x?martech=off
- After: https://a11y-edit-template-link--express-milo--adobecom.hlx.page/docs/authoring/template-x?martech=off
- Before: https://main--express-milo--adobecom.hlx.page/express/experiments/opt-31333/poc?martech=off
- After: https://a11y-edit-template-link--express-milo--adobecom.hlx.page/express/experiments/opt-31333/poc?martech=off

Testing notes:
Turn on screen reader. View both sample pages above. Tab to "edit this template" button. The screen reader will now read that text along with the template name.