### PR TITLE
[MWPW-168469] Stage domains map

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -41,20 +41,15 @@ const CONFIG = {
   codeRoot: '/express/code',
   contentRoot: '/express',
   stageDomainsMap: {
-    '--express-milo--adobecom.hlx.page': {
+    '--express-milo--adobecom.(hlx|aem).page': {
       'www.adobe.com': 'www.stage.adobe.com',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
-      'http://express.adobe.com/': 'stage.projectx.corp.adobe.com',
-    },
-    '--express-milo--adobecom.hlx.live': {
-      'www.adobe.com': 'www.stage.adobe.com',
-      'commerce.adobe.com': 'commerce-stg.adobe.com',
-      'http://express.adobe.com/': 'stage.projectx.corp.adobe.com',
+      'express.adobe.com/': 'stage.projectx.corp.adobe.com',
     },
     'www.stage.adobe.com': {
       'www.adobe.com': 'origin',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
-      'http://express.adobe.com/': 'stage.projectx.corp.adobe.com',
+      'express.adobe.com/': 'stage.projectx.corp.adobe.com',
     },
   },
   jarvis: {

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -44,11 +44,13 @@ const CONFIG = {
     '--express-milo--adobecom.(hlx|aem).page': {
       'www.adobe.com': 'www.stage.adobe.com',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
+      'new.express.adobe.com': 'stage.projectx.corp.adobe.com',
       'express.adobe.com': 'stage.projectx.corp.adobe.com',
     },
     'www.stage.adobe.com': {
       'www.adobe.com': 'origin',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
+      'new.express.adobe.com': 'stage.projectx.corp.adobe.com',
       'express.adobe.com': 'stage.projectx.corp.adobe.com',
     },
   },

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -44,12 +44,12 @@ const CONFIG = {
     '--express-milo--adobecom.(hlx|aem).page': {
       'www.adobe.com': 'www.stage.adobe.com',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
-      'express.adobe.com/': 'stage.projectx.corp.adobe.com',
+      'express.adobe.com': 'stage.projectx.corp.adobe.com',
     },
     'www.stage.adobe.com': {
       'www.adobe.com': 'origin',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
-      'express.adobe.com/': 'stage.projectx.corp.adobe.com',
+      'express.adobe.com': 'stage.projectx.corp.adobe.com',
     },
   },
   jarvis: {

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -40,6 +40,23 @@ const CONFIG = {
   prod: { express: 'express.adobe.com', commerce: 'commerce.adobe.com' },
   codeRoot: '/express/code',
   contentRoot: '/express',
+  stageDomainsMap: {
+    '--express-milo--adobecom.hlx.page': {
+      'www.adobe.com': 'www.stage.adobe.com',
+      'commerce.adobe.com': 'commerce-stg.adobe.com',
+      'http://express.adobe.com/': 'stage.projectx.corp.adobe.com',
+    },
+    '--express-milo--adobecom.hlx.live': {
+      'www.adobe.com': 'www.stage.adobe.com',
+      'commerce.adobe.com': 'commerce-stg.adobe.com',
+      'http://express.adobe.com/': 'stage.projectx.corp.adobe.com',
+    },
+    'www.stage.adobe.com': {
+      'www.adobe.com': 'origin',
+      'commerce.adobe.com': 'commerce-stg.adobe.com',
+      'http://express.adobe.com/': 'stage.projectx.corp.adobe.com',
+    },
+  },
   jarvis: {
     id: getMetadata('jarvis-surface-id') || 'Acom_Express',
     version: getMetadata('jarvis-surface-version') || '1.0',

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -41,7 +41,7 @@ const CONFIG = {
   codeRoot: '/express/code',
   contentRoot: '/express',
   stageDomainsMap: {
-    '--express-milo--adobecom.(hlx|aem).page': {
+    '--express-milo--adobecom.(hlx|aem).(page|live)': {
       'www.adobe.com': 'www.stage.adobe.com',
       'commerce.adobe.com': 'commerce-stg.adobe.com',
       'new.express.adobe.com': 'stage.projectx.corp.adobe.com',


### PR DESCRIPTION
Add `stageDomainsMap` to Express's config so that we can have auto link-mapping/replacement for authored links.

Resolves: https://jira.corp.adobe.com/browse/MWPW-168469

How to test:
On the page, click or hover onto the middle "Enter class code" CTA and notice that it's linking to the stage url of product rather than the default author prod one.

Test URLs:
- Before: https://main--express-milo--adobecom.aem.page/education/express/?martech=off
- After: https://stage-domains-map--express-milo--adobecom.aem.page/education/express/?martech=off
