### PR TITLE
Business Hub - mWeb / Desktop - Pricing Card Block

### DIFF
--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -35,7 +35,7 @@ main .section>.simplified-pricing-cards-wrapper {
 }
 
 .simplified-pricing-cards .card {
-    width: calc(var(--card-width) - 32px);
+    width: calc(var(--card-width) - 34px);
     position: relative;
     padding: 16px;
     border: 2px solid var(--color-gray-300);

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -320,7 +320,7 @@ main .section>.simplified-pricing-cards-wrapper {
     background-color: var(--color-white);
     border: 2px solid var(--color-black);
     color: black;
-    margin: 24px auto 24px auto;
+    margin: 40px auto 24px auto;
     padding-top: 12px;
     padding-bottom: 12px;
     border-radius: 24px;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -25,7 +25,6 @@ main .section>.simplified-pricing-cards-wrapper {
     flex-wrap: wrap;
     gap: 16px;
     flex-direction: column;
-    width: fit-content;
     margin: 16px auto auto auto;
 }
 
@@ -534,6 +533,7 @@ main .section>.simplified-pricing-cards-wrapper {
     .simplified-pricing-cards .card-wrapper {
         margin: auto;
         flex-direction: row;
+        width: fit-content;
     }
 
     .simplified-pricing-cards .pricing-area-wrapper {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -29,6 +29,11 @@ main .section>.simplified-pricing-cards-wrapper {
     margin: 16px auto auto auto;
 }
 
+.simplified-pricing-cards.wide {
+    --card-width: 100%;
+    padding: 16px;
+}
+
 .simplified-pricing-cards .card {
     width: calc(var(--card-width) - 32px);
     position: relative;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -451,6 +451,11 @@ main .section>.simplified-pricing-cards-wrapper {
         --header-offer-size: 16px;
     }
 
+    .simplified-pricing-cards.wide {
+        --card-width: 580px;
+        padding: unset;
+    }
+
     .simplified-pricing-cards .card-wrapper {
         margin: 48px auto;
         width: min-content;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -259,6 +259,20 @@ function decorateCardBorder(card, source) {
   source.style.display = 'none';
 }
 
+function getDefaultExpandedIndex(el) {
+  let defaultOpenIndex =0
+  let q = undefined
+  el.classList.forEach((cl) => {
+    if (cl.includes('default-expanded-')) {
+      q = cl
+    }
+  }) 
+  if (q) {
+    defaultOpenIndex = parseInt(q.split('default-expanded-')[1]) - 1
+  }
+  return defaultOpenIndex
+}
+
 export default async function init(el) {
   addTempWrapperDeprecated(el, 'simplified-pricing-cards');
   await Promise.all([import(`${getLibs()}/utils/utils.js`), import(`${getLibs()}/features/placeholders.js`), import('../../scripts/utils/location-utils.js')]).then(([utils, placeholders, locationUtils]) => {
@@ -271,10 +285,12 @@ export default async function init(el) {
   const cardCount = rows[0].children.length;
   const cards = [];
 
+  const defaultOpenIndex = getDefaultExpandedIndex(el)
+ 
   /* eslint-disable no-await-in-loop */
   for (let cardIndex = 0; cardIndex < cardCount; cardIndex += 1) {
     const card = createTag('div', { class: 'card' });
-    if (cardIndex > 0) {
+    if (cardIndex != defaultOpenIndex) {
       card.classList.add('hide');
     }
     decorateCardBorder(card, rows[1].children[0]);


### PR DESCRIPTION
Describe your specific features or fixes:
* Pricing cards set to 100% with a 16px left and right padding 
* Updated top padding of the compare all button
* For changing the spacing of the bottom of the block use the new milo sectioin metadata style tokens
* Added variants for specifying  which card to be open by default on mobile
* Use `default-expanded-1` for the first card, `default-expanded-2` for the second card, etc

<img width="562" alt="Screenshot 2025-02-26 at 4 01 09 PM" src="https://github.com/user-attachments/assets/f013ec76-afac-4de2-8c2d-8669a1f6114f" />
<img width="440" alt="Screenshot 2025-02-26 at 4 01 17 PM" src="https://github.com/user-attachments/assets/53024350-a759-4d90-927c-f3329f2680a5" />

Authoring Changes Required

Authoring Example: [business-hub-pricing-cards-desktop.docx](https://adobe.sharepoint.com/:w:/r/sites/adobecom/Express/website/drafts/jsandlan/business-hub-pricing-cards-desktop.docx?d=wfadd3b18e478487288aba0a3025d1fe1&csf=1&web=1&e=SEJLSF)

<img width="719" alt="Screenshot 2025-02-26 at 11 33 11 AM" src="https://github.com/user-attachments/assets/24aaba97-92c6-4a3a-b99e-883aa0110d5a" />

<img width="1161" alt="Screenshot 2025-02-26 at 11 34 35 AM" src="https://github.com/user-attachments/assets/f1df337e-2f70-4eb9-ac44-f383dd9a5368" />


**mWeb**
Resolves: [MWPW-168292](https://jira.corp.adobe.com/browse/MWPW-168292)
https://jira.corp.adobe.com/browse/MWPW-168278

<img width="414" alt="Screenshot 2025-02-25 at 2 04 21 PM" src="https://github.com/user-attachments/assets/f1146792-2af8-4089-b599-9dec19596576" />

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://www.stage.adobe.com/express/business
- **After**
**Entire Page**: https://pricing-cards-wide-mobile--express-milo--adobecom.hlx.page/express/business
**Pricing Cards Only**: https://pricing-cards-wide-mobile--express-milo--adobecom.hlx.page/express/pricing
**Pricing Cards With Configured Default Open Setting** https://pricing-cards-wide-mobile--express-milo--adobecom.hlx.page/drafts/echen/individuals-and-teams-upgrade
