### PR TITLE
Business Hub - mWeb - Compare Express V/S Canva Blade

### DIFF
--- a/express/code/blocks/headline/headline.css
+++ b/express/code/blocks/headline/headline.css
@@ -10,6 +10,14 @@
     margin: auto;
 }
 
+.section > .headline.business-hub h2 {
+    font-size: 22px;
+    padding-left: 16px;
+    padding-right: 16px;
+    margin-top: 32px;
+    margin-bottom: 24px;
+}
+
 @media (min-width: 900px) {
     .section > .headline {
         max-width: 830px;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -458,17 +458,36 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   text-align: left;
 }
 
+.pricing-table.collapsible-rows .row:not(.row-heading) {
+  padding: 24px 0;
+}
+
 .pricing-table.collapsible-rows .row:not(.row-heading) .col.col-2,
 .pricing-table.collapsible-rows .row:not(.row-heading) .col.col-3 {
   padding-left: 16px;
   padding-right: 16px;
+  background-color: #F8F8F8;
+  position: relative;
+  border-color: #E9E9E9;
+}
+
+.pricing-table.collapsible-rows .row:not(.row-heading) .col.col-2::before,
+.pricing-table.collapsible-rows .row:not(.row-heading) .col.col-3::before {
+  content: '';
+  position: absolute;
+  top: -8px;
+  bottom: -8px;
+  left: 0;
+  right: 0;
+  background-color: #F8F8F8;
+  z-index: -1;
 }
 
 .pricing-table.collapsible-rows .row:not(.row-heading) .col.col-1 {
   flex-direction: row;
   justify-content: left;
   font-size: 14px;
-  background-color: white;
+  background-color: inherit;
   padding: 16px;
   border-bottom: 1px solid #E9E9E9;
   border-top: 1px solid #E9E9E9;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -823,6 +823,9 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   main .section .pricing-table-wrapper .pricing-table {
     margin: 0px 20px;
   }
+  main .section .pricing-table-wrapper .pricing-table.collapsible-rows {
+    padding-bottom: 0;
+  }
 
   .pricing-table {
     margin: 0 30px;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -516,6 +516,10 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   font-size: 13px;
 }
 
+.pricing-table.collapsible-rows .row:not(.row-heading) .toggle-row.collapsed {
+  margin-top: -9px;
+}
+
 .pricing-table .row.section-row .col .col-heading {
   display: none;
 }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -293,7 +293,8 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   appearance: unset;
   width: 100%;
 }
-.pricing-table .row.toggle-row .col.toggle-content {
+.pricing-table .row.toggle-row .col.toggle-content,
+.pricing-table.business-hub .row .toggle-row {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -453,6 +453,16 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   text-align: left;
 }
 
+.pricing-table.business-hub .row:not(.row-heading) .col.col-1 {
+  flex-direction: row;
+  justify-content: left;
+  font-size: 14px;
+}
+
+.pricing-table.business-hub .row:not(.row-heading) .toggle-row {
+  font-size: 13px;
+}
+
 .pricing-table .row.section-row .col .col-heading {
   display: none;
 }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -764,6 +764,9 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   .pricing-table.collapsible-rows .row.toggle-row .col {
     padding: 0;
   }
+  .pricing-table.collapsible-rows .row.section-row {
+    border-radius: 8px;
+  }
   .pricing-table .row.toggle-row.desktop-hide {
     display: grid;
   }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -506,7 +506,6 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   background-color: inherit;
   padding: 16px;
   border-bottom: 1px solid #E9E9E9;
-  border-top: 1px solid #E9E9E9;
 }
 .pricing-table.collapsible-rows .row.table-start-row .col:last-child {
   border-top-right-radius: 0;
@@ -514,6 +513,12 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 
 .pricing-table.collapsible-rows .row:not(.row-heading) .toggle-row {
   font-size: 13px;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  border-top: 1px solid #E9E9E9;
+  border-bottom: 1px solid #E9E9E9;
+  border-left: 0;
+  border-right: 0;
 }
 
 .pricing-table.collapsible-rows .row:not(.row-heading) .toggle-row.collapsed {

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -74,8 +74,9 @@
 }
 
 .pricing-table .row-heading .col-heading .tracking-header {
-  font-size: 1.375rem;
+  font-size: 18px;
   line-height: 130%;
+  margin: auto;
 }
 
 .pricing-table .row-heading .col-heading .body {
@@ -155,6 +156,25 @@
 .top-border-transparent {
   border-top: 1px solid transparent;
 }
+
+.pricing-table-wrapper .pricing-table.business-hub {
+  padding-top: 0;
+  margin-top: 24px;
+}
+
+.pricing-table-wrapper .pricing-table.business-hub .row-heading .col {
+  padding: 0;
+}
+
+.pricing-table.business-hub .row.row-heading {
+  margin-bottom: 4px;
+}
+
+.pricing-table.business-hub .row.section-row .col.col-1 p:first-child {
+  font-size: 22px;
+  color: #505050;
+}
+
 
 @media (min-width: 900px) {
   .pricing-table > .row {

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -82,6 +82,9 @@
   line-height: 130%;
   margin: auto;
 }
+.pricing-table.collapsible-rows .row-heading .col-heading .tracking-header {
+  margin-bottom: 20px;
+}
 
 .pricing-table .row-heading .col-heading .body {
   font-size: var(--body-font-size-m);

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -180,6 +180,11 @@
   color: #505050;
 }
 
+.pricing-table.collapsible-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
 
 @media (min-width: 900px) {
   .pricing-table > .row {
@@ -453,11 +458,23 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   text-align: left;
 }
 
+.pricing-table.collapsible-rows .row:not(.row-heading) .col.col-2,
+.pricing-table.collapsible-rows .row:not(.row-heading) .col.col-3 {
+  padding-left: 16px;
+  padding-right: 16px;
+}
+
 .pricing-table.collapsible-rows .row:not(.row-heading) .col.col-1 {
   flex-direction: row;
   justify-content: left;
   font-size: 14px;
   background-color: white;
+  padding: 16px;
+  border-bottom: 1px solid #E9E9E9;
+  border-top: 1px solid #E9E9E9;
+}
+.pricing-table.collapsible-rows .row.table-start-row .col:last-child {
+  border-top-right-radius: 0;
 }
 
 .pricing-table.collapsible-rows .row:not(.row-heading) .toggle-row {
@@ -702,6 +719,11 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   .pricing-table .row.section-row,
   .pricing-table .row.toggle-row .col {
     padding: 16px;
+  }
+  .pricing-table.collapsible-rows .row.section-header-row .col,
+  .pricing-table.collapsible-rows .row.section-row,
+  .pricing-table.collapsible-rows .row.toggle-row .col {
+    padding: 0;
   }
   .pricing-table .row.toggle-row.desktop-hide {
     display: grid;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -457,6 +457,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   flex-direction: row;
   justify-content: left;
   font-size: 14px;
+  background-color: white;
 }
 
 .pricing-table.collapsible-rows .row:not(.row-heading) .toggle-row {

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -186,6 +186,14 @@
   gap: 24px;
 }
 
+.pricing-table.collapsible-rows > .row:first-child {
+  margin-bottom: -10px;
+}
+
+.pricing-table.collapsible-rows > .row:nth-child(2) {
+  margin-top: -10px;
+}
+
 @media (min-width: 900px) {
   .pricing-table > .row {
     grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
@@ -286,6 +294,9 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 .pricing-table .row.blank-row {
   height: 40px;
 }
+.pricing-table.collapsible-rows .row.blank-row {
+  display: none;
+}
 /* /Blank Row */
 
 /* Toggle Row */
@@ -318,11 +329,16 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 .pricing-table .row.toggle-row:hover .col.toggle-content {
   text-decoration: underline;
 }
-.pricing-table .row.toggle-row .col.toggle-content .icon.expand,
-.pricing-table.collapsible-rows .row .toggle-row span.icon.expand {
+.pricing-table .row.toggle-row .col.toggle-content .icon.expand {
   height: 18px;
   width: 18px;
 }
+.pricing-table.collapsible-rows .row .toggle-row span.icon.expand {
+  height: 14px;
+  width: 14px;
+  background-size: 14px;
+}
+
 .pricing-table .row.toggle-row .col {
   white-space: nowrap;
 }
@@ -486,7 +502,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 .pricing-table.collapsible-rows .row:not(.row-heading) .col.col-1 {
   flex-direction: row;
   justify-content: left;
-  font-size: 14px;
+  font-size: 12px;
   background-color: inherit;
   padding: 16px;
   border-bottom: 1px solid #E9E9E9;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -313,7 +313,8 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
 .pricing-table .row.toggle-row:hover .col.toggle-content {
   text-decoration: underline;
 }
-.pricing-table .row.toggle-row .col.toggle-content .icon.expand {
+.pricing-table .row.toggle-row .col.toggle-content .icon.expand,
+.pricing-table.business-hub .row .toggle-row span.icon.expand {
   height: 18px;
   width: 18px;
 }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -157,6 +157,11 @@
   border-top: 1px solid transparent;
 }
 
+.pricing-table.business-hub .additional-row .col-1.collapsed,
+.pricing-table.business-hub .additional-row .col-2.collapsed {
+  display: none;
+}
+
 .pricing-table-wrapper .pricing-table.business-hub {
   padding-top: 0;
   margin-top: 24px;

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -157,8 +157,8 @@
   border-top: 1px solid transparent;
 }
 
-.pricing-table.business-hub .additional-row .col-1.collapsed,
-.pricing-table.business-hub .additional-row .col-2.collapsed {
+.pricing-table.business-hub .additional-row .col-2.collapsed,
+.pricing-table.business-hub .additional-row .col-3.collapsed {
   display: none;
 }
 

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -157,25 +157,25 @@
   border-top: 1px solid transparent;
 }
 
-.pricing-table.business-hub .additional-row .col-2.collapsed,
-.pricing-table.business-hub .additional-row .col-3.collapsed {
+.pricing-table.collapsible-rows .additional-row .col-2.collapsed,
+.pricing-table.collapsible-rows .additional-row .col-3.collapsed {
   display: none;
 }
 
-.pricing-table-wrapper .pricing-table.business-hub {
+.pricing-table-wrapper .pricing-table.collapsible-rows {
   padding-top: 0;
   margin-top: 24px;
 }
 
-.pricing-table-wrapper .pricing-table.business-hub .row-heading .col {
+.pricing-table-wrapper .pricing-table.collapsible-rows .row-heading .col {
   padding: 0;
 }
 
-.pricing-table.business-hub .row.row-heading {
+.pricing-table.collapsible-rows .row.row-heading {
   margin-bottom: 4px;
 }
 
-.pricing-table.business-hub .row.section-row .col.col-1 p:first-child {
+.pricing-table.collapsible-rows .row.section-row .col.col-1 p:first-child {
   font-size: 22px;
   color: #505050;
 }
@@ -294,7 +294,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   width: 100%;
 }
 .pricing-table .row.toggle-row .col.toggle-content,
-.pricing-table.business-hub .row .toggle-row {
+.pricing-table.collapsible-rows .row .toggle-row {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -314,7 +314,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   text-decoration: underline;
 }
 .pricing-table .row.toggle-row .col.toggle-content .icon.expand,
-.pricing-table.business-hub .row .toggle-row span.icon.expand {
+.pricing-table.collapsible-rows .row .toggle-row span.icon.expand {
   height: 18px;
   width: 18px;
 }
@@ -453,13 +453,13 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   text-align: left;
 }
 
-.pricing-table.business-hub .row:not(.row-heading) .col.col-1 {
+.pricing-table.collapsible-rows .row:not(.row-heading) .col.col-1 {
   flex-direction: row;
   justify-content: left;
   font-size: 14px;
 }
 
-.pricing-table.business-hub .row:not(.row-heading) .toggle-row {
+.pricing-table.collapsible-rows .row:not(.row-heading) .toggle-row {
   font-size: 13px;
 }
 

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -86,6 +86,10 @@
   margin-bottom: 20px;
 }
 
+.pricing-table.collapsible-rows .col-wrapper {
+  height: 36px;
+}
+
 .pricing-table .row-heading .col-heading .body {
   font-size: var(--body-font-size-m);
 }

--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -29,6 +29,10 @@
   margin-right: 8px;
 }
 
+.pricing-table-wrapper:has(.pricing-table.collapsible-rows) {
+  margin-top: -5px;
+}
+
 /* links stay links by default in cells */
 .pricing-table .row:not(.row-heading) .col a.button,
 .pricing-table .row:not(.row-heading) .col a.button:hover,

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -157,7 +157,7 @@ function handleSection(sectionParams) {
         child.innerHTML = `<p >${col.innerHTML}</p>`;
       }
     });
-    if (nextRow.classList.contains('toggle-row')) {
+    if (nextRow?.classList.contains('toggle-row')) {
       row.classList.add('table-end-row');
 
       if (!nextRow.classList.contains('desktop-hide')) {
@@ -281,7 +281,7 @@ export default async function init(el) {
     }
 
     const nextRow = rows[index + 1];
-    if (index > 0 && !isToggle && cols.length > 1
+    if (!isCollapsibleRowsVariant && index > 0 && !isToggle && cols.length > 1
       && (!nextRow || Array.from(nextRow.children).length <= 1)) {
       const toggleRow = createTag('button', { class: 'toggle-row' });
       if (!isAdditional) toggleRow.classList.add('desktop-hide');

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -252,14 +252,13 @@ export default async function init(el) {
         }, 'View all features');
 
         toggleBtn.addEventListener('click', () => {
-          const newExpandedState = toggleBtn.getAttribute('aria-expanded') !== 'true';
-          toggleBtn.setAttribute('aria-expanded', newExpandedState.toString());
-
-          const colsToToggle = row.querySelectorAll('.col-2:not(button), .col-3:not(button)');
+          const isExpanded = toggleBtn.getAttribute('aria-expanded') !== 'true';
+          toggleBtn.setAttribute('aria-expanded', isExpanded.toString());
+          const colsToToggle = row.querySelectorAll('[data-col-index="2"], [data-col-index="3"]');
 
           requestAnimationFrame(() => {
             colsToToggle.forEach((col) => {
-              if (newExpandedState) {
+              if (isExpanded) {
                 col.classList.add('collapsed');
               } else {
                 col.classList.remove('collapsed');

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -243,6 +243,34 @@ export default async function init(el) {
         col.classList.add('col', `col-${cdx + 1}`);
         col.setAttribute('role', 'cell');
       });
+
+      // Add our test column to additional rows
+      if (isAdditional && cols.length > 1) {
+        const toggleBtn = createTag('button', {
+          class: 'toggle-row toggle-content col col-1',
+          'aria-expanded': 'false',
+        }, 'View all features');
+
+        toggleBtn.addEventListener('click', () => {
+          const newExpandedState = toggleBtn.getAttribute('aria-expanded') !== 'true';
+          toggleBtn.setAttribute('aria-expanded', newExpandedState.toString());
+
+          const colsToToggle = row.querySelectorAll('.col-2:not(button), .col-3:not(button)');
+
+          requestAnimationFrame(() => {
+            colsToToggle.forEach((col) => {
+              if (newExpandedState) {
+                col.classList.add('collapsed');
+              } else {
+                col.classList.remove('collapsed');
+              }
+            });
+          });
+        });
+
+        row.appendChild(toggleBtn);
+      }
+
       if (sectionItem % 2 === 0 && cols.length > 1) row.classList.add('shaded');
     } else {
       row.setAttribute('tabindex', 0);

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -250,7 +250,8 @@ export default async function init(el) {
           class: 'toggle-row toggle-content col col-1',
           'aria-expanded': 'false',
         }, 'View all features');
-
+        const toggleIconTag = createTag('span', { class: 'icon expand', 'aria-expanded': firstSection });
+        toggleBtn.prepend(toggleIconTag);
         toggleBtn.addEventListener('click', () => {
           const isExpanded = toggleBtn.getAttribute('aria-expanded') !== 'true';
           toggleBtn.setAttribute('aria-expanded', isExpanded.toString());

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -248,10 +248,12 @@ export default async function init(el) {
 
       // Add our test column to additional rows
       if (isCollapsibleRowsVariant && isAdditional && cols.length > 1) {
+        const viewAllText = viewAllFeatures ?? 'View all features';
         const toggleBtn = createTag('button', {
           class: 'toggle-row toggle-content col col-1',
           'aria-expanded': 'false',
-        }, 'View all features');
+          'aria-label': viewAllText,
+        }, viewAllText);
         const toggleIconTag = createTag('span', { class: 'icon expand', 'aria-expanded': firstSection });
         toggleBtn.prepend(toggleIconTag);
         toggleBtn.addEventListener('click', () => {

--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -202,6 +202,8 @@ export default async function init(el) {
   await fixIcons(el);
   splitAndAddVariantsWithDash(el);
 
+  const isCollapsibleRowsVariant = el.classList.contains('collapsible-rows');
+
   addTempWrapperDeprecated(el, 'pricing-table');
   await Promise.all([import(`${getLibs()}/utils/utils.js`), import(`${getLibs()}/features/placeholders.js`)]).then(([utils, placeholders]) => {
     ({ createTag, getConfig } = utils);
@@ -245,7 +247,7 @@ export default async function init(el) {
       });
 
       // Add our test column to additional rows
-      if (isAdditional && cols.length > 1) {
+      if (isCollapsibleRowsVariant && isAdditional && cols.length > 1) {
         const toggleBtn = createTag('button', {
           class: 'toggle-row toggle-content col col-1',
           'aria-expanded': 'false',

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -209,6 +209,11 @@ main svg.icon-milo, main img.icon-milo {
 }
 
 
+.text-block .foreground > .cta-container .body-m.action-area a {
+  margin-top: unset;
+}
+
+
 main a.con-button.button-l:any-link,
 main a.con-button.l-button:any-link,
 main .button-l a.con-button:any-link,


### PR DESCRIPTION
Describe your specific features or fixes:
* Padding between the Headline and Compare features copy should be 24px
* 'Compare features' text is Adobe Clean Bold 18px
* 'Compare features' text is centre-aligned
* Padding between 'Compare features' and the first table item is 32px
* Each table section for comparison should be in its own collapsible card. The first card is displayed as opened by default. 
* Padding between each collapsible card is 24px
* Ensure cards have 8px corner radius on all 4 corners
* Hide Canva Teams Row Icon
* Padding between line item title container, outer edge of checkmark/X icon circle, and item description container should be 16px.

Resolves: [MWPW-168289](https://jira.corp.adobe.com/browse/MWPW-168289)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://www.stage.adobe.com/express/business
- After: https://business-hub-compare-blade--express-milo--adobecom.aem.page/drafts/jsandlan/business-hub-compare-blade
