### PR TITLE
[MWPW-168746] Enable summit bacom dynamic nav

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -85,6 +85,7 @@ const CONFIG = {
   autoBlocks: [
     { axfaas: '/tools/axfaas' },
   ],
+  dynamicNavKey: 'bacom',
   languageMap: {
     ae_ar: '',
     ae_en: '',


### PR DESCRIPTION
One-line change that adds a key to enable cross-site nav between our business pages and BACOM pages during Summit25. This is low-risk should have no impact on any of our pages, but will unblock authors and PdMs in planning out this feature in drafts.

Resolves: https://jira.corp.adobe.com/browse/MWPW-168746

Test URLs:
- Before: https://main--express-milo--adobecom.aem.live/express/?martech=off
- After: https://dynamic-nav-key--express-milo--adobecom.aem.live/express/?martech=off

Docs: 
https://main--milo--adobecom.hlx.page/docs/authoring/features/dynamic-navigation
https://main--milo--adobecom.hlx.page/docs/authoring/feds/global-navigation#accordion-1-trigger-18