### PR TITLE
[ACE1057] Grid marquee toggle CSS fix to fit bigger header subtitle

### DIFF
--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.css
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.css
@@ -346,7 +346,7 @@ main .section .grid-marquee h1 {
 .grid-marquee .slider.round:before {
   border-radius: 50%;
 }
-
+/* button look change */
 .grid-marquee.toggle .ctas a:nth-child(2) {
   transition: none;
   background: none;
@@ -361,7 +361,7 @@ main .section .grid-marquee h1 {
     max-height: 1200px;
   }
   .grid-marquee .headline {
-    max-width: 1200px;
+    max-width: 1000px;
   }
   .grid-marquee .headline .ctas {
     display: flex;

--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.css
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.css
@@ -424,7 +424,7 @@ main .section .grid-marquee h1 {
     max-width: 1800px;
   }
   .grid-marquee .headline {
-    max-width: 1600px;
+    max-width: 1000px;
     padding-bottom: 40px;
   }
   main .section .grid-marquee .headline h1 {


### PR DESCRIPTION
CSS fix to fit bigger header subtitle

Resolves: [OPT-31772](https://jira.corp.adobe.com/browse/OPT-31772)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://grid-marquee-toggle--express-milo--adobecom.aem.page/express/fragments/tests/2025/q1/ace1057/index-ace1057?mep=%2Fexpress%2Ffragments%2Ftests%2F2025%2Fq1%2Face1057%2Face1057.json
