### PR TITLE
ACE1057 : bug fix for video anchor missing when using replacePage action

### DIFF
--- a/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
+++ b/express/code/scripts/mep/ace1057/grid-marquee/grid-marquee.js
@@ -130,7 +130,8 @@ function toCard(drawer) {
   const panelsFrag = new DocumentFragment();
   panelsFrag.append(...panels);
   panels.forEach((panel) => panel.classList.add('panel'));
-  const videoAnchor = face.querySelector('a');
+  const videoAnchor = face.querySelector('a') || face.querySelector('video');
+  const videoSrc = videoAnchor?.href || videoAnchor?.dataset.videoSource;
   videoAnchor?.remove();
   const card = createTag('button', {
     class: 'card',
@@ -141,7 +142,7 @@ function toCard(drawer) {
 
   face.classList.add('face');
   addCardInteractions(card, drawer);
-  const lazyCB = () => decorateDrawer(videoAnchor.href, face.querySelector('img').src, titleText, panels, panelsFrag, drawer);
+  const lazyCB = () => decorateDrawer(videoSrc, face.querySelector('img').src, titleText, panels, panelsFrag, drawer);
   drawer.classList.add('drawer');
   drawer.setAttribute('aria-hidden', true);
   drawer.id = `drawer-${titleText}`;


### PR DESCRIPTION
When page is being replaced with a fragment <a> anchors are being converted to <video> tags, but the code still expects <a> tags to be present to pull video src from. 

Resolves: [OPT-31772](https://jira.corp.adobe.com/browse/OPT-31772)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https:/stage--express-milo--adobecom.aem.page/express/?mep=%2Fexpress%2Ffragments%2Ftests%2F2025%2Fq1%2Face1057%2Face1057.json&audience=b2b

- After: https://grid-marquee-toggle--express-milo--adobecom.aem.page/express/?mep=%2Fexpress%2Ffragments%2Ftests%2F2025%2Fq1%2Face1057%2Face1057.json&audience=b2b
