### PR TITLE
[Accessibility] How-To Block Enhancement

### DIFF
--- a/express/code/blocks/how-to-v2/how-to-v2.js
+++ b/express/code/blocks/how-to-v2/how-to-v2.js
@@ -6,13 +6,16 @@ function setStepDetails(block, indexOpenedStep) {
 
   listItems.forEach((item, i) => {
     const detail = item.querySelector('.detail-container');
+    const isOpen = i === indexOpenedStep;
 
-    if (i === indexOpenedStep) {
+    if (isOpen) {
       detail.classList.remove('closed');
       detail.style.maxHeight = `${detail.scrollHeight}px`;
+      item.setAttribute('aria-expanded', 'true');
     } else {
       detail.classList.add('closed');
       detail.style.maxHeight = '0';
+      item.setAttribute('aria-expanded', 'false');
     }
   });
 }
@@ -27,7 +30,11 @@ function buildAccordion(block, rows, stepsContent) {
     const newStepTitle = createTag('h3');
     newStepTitle.replaceChildren(...stepTitle.childNodes);
 
-    const listItem = createTag('LI', { class: 'step', tabindex: '0' });
+    const listItem = createTag('LI', {
+      class: 'step',
+      tabindex: '0',
+      'aria-expanded': i === 0 ? 'true' : 'false',
+    });
     list.append(listItem);
 
     const listItemIndicator = createTag('div', { class: 'step-indicator' });

--- a/express/code/blocks/how-to-v2/how-to-v2.js
+++ b/express/code/blocks/how-to-v2/how-to-v2.js
@@ -27,10 +27,12 @@ function buildAccordion(block, rows, stepsContent) {
   rows.forEach((row, i) => {
     const [stepTitle, stepDetail] = row.querySelectorAll(':scope div');
 
-    const newStepTitle = createTag('h3');
+    const titleId = `step-title-${i}`;
+    const detailId = `step-detail-${i}`;
+
+    const newStepTitle = createTag('h3', { id: titleId });
     newStepTitle.replaceChildren(...stepTitle.childNodes);
 
-    const detailId = `step-detail-${i}`;
     const listItem = createTag('LI', {
       class: 'step',
       tabindex: '0',
@@ -48,6 +50,7 @@ function buildAccordion(block, rows, stepsContent) {
     const detailContainer = createTag('div', {
       class: 'detail-container',
       id: detailId,
+      'aria-labelledby': titleId,
     });
 
     if (i !== 0) {

--- a/express/code/blocks/how-to-v2/how-to-v2.js
+++ b/express/code/blocks/how-to-v2/how-to-v2.js
@@ -30,10 +30,12 @@ function buildAccordion(block, rows, stepsContent) {
     const newStepTitle = createTag('h3');
     newStepTitle.replaceChildren(...stepTitle.childNodes);
 
+    const detailId = `step-detail-${i}`;
     const listItem = createTag('LI', {
       class: 'step',
       tabindex: '0',
       'aria-expanded': i === 0 ? 'true' : 'false',
+      'aria-controls': detailId,
     });
     list.append(listItem);
 
@@ -43,7 +45,10 @@ function buildAccordion(block, rows, stepsContent) {
     const detailText = stepDetail;
     detailText && detailText.classList.add('detail-text');
 
-    const detailContainer = createTag('div', { class: 'detail-container' });
+    const detailContainer = createTag('div', {
+      class: 'detail-container',
+      id: detailId,
+    });
 
     if (i !== 0) {
       detailContainer.classList.add('closed');


### PR DESCRIPTION
Describe your specific features or fixes:
* Adds a11y features outlined in document below: 
* Upon hitting "Enter/Return" a step that is closed, will open. 
* If a step is already open, hitting "Enter/Return" will NOT close that step.
* ARIA-EXPANDED: value is "false" when accordion is closed. "true" when accordion is open.
* ARIA-CONTROLS: value should be equal to the id of the content that will expand. This will indicate what content will be shown upon expand to users (in other words, what is being controlled by the button).
* ARIA-LABELLEDBY: should be the value of the id for the question button (the H3 title). This applies to all content for each accordion item.

[Annotations for the How-to Block](https://www.figma.com/design/BZFcWZY01SWY9FRXB4cIVv/Standout-Create-Page-test---CCEX-120989?node-id=3866-279329&t=VTjyHhx2M6pr5lEf-11)

<img width="1295" alt="how-to-v2" src="https://github.com/user-attachments/assets/f6bc4615-a8bd-48d3-921a-78a0675c1513" />


Resolves: [MWPW-166011](https://jira.corp.adobe.com/browse/MWPW-166011)

Test URLs:
- Feature Branch: https://milo-how-to-block-a11y--express-milo--adobecom.aem.page/drafts/jsandlan/milo-how-to-v2
