### PR TITLE
[JDI SPOT FIX] Hiding non loaded promotion

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -629,6 +629,10 @@ main .hero-animation {
   transition: opacity 100ms;
 }
 
+main .promotion.auto-promotion:not([data-block-status="loaded"]) {
+  display: none;
+}
+
 /* free plan widget */
 main .button-container.free-plan-container {
   position: relative;


### PR DESCRIPTION
On pages that run the auto promotion, the HTML that isn't transformed via JS yet shows up on the page as seen here: 

<img width="228" alt="image" src="https://github.com/user-attachments/assets/b142dff7-db54-4dfd-9fae-ae603fa59469" />

This just hides that in styles.css, so it loads fast enough (promotion.css will come too late) 

No ticket, would take longer to write the ticket than JDI for this. 

Test URLs:
- Before: https://main--express-milo--adobecom.aem.page/express/?martech=off
- After: https://promo-hide--express-milo--adobecom.aem.page/express/?martech=off
