### PR TITLE
[Urgent Hotfix][MWPW-169944] Commerce Link Override by blocks specified by Page-level Metadata

### DIFF
--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -767,7 +767,7 @@ async function formatDynamicCartLink(a) {
 
 function decorateCommerceLinks(area) {
   const blocks = getMetadata('ax-commerce-override')?.toLowerCase()?.split(',') || [];
-  const selector = blocks.map((block) => `.${block} a`).join(', ');
+  const selector = blocks.map((block) => `.${block.trim()} a`).join(', ');
   selector && [...area.querySelectorAll(selector)].forEach((a) => {
     formatDynamicCartLink(a);
   });

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -740,6 +740,39 @@ function splitSections(area, selector) {
   });
 }
 
+async function formatDynamicCartLink(a) {
+  try {
+    const pattern = /.*commerce.*adobe\.com.*/gm;
+    if (!pattern.test(a.href)) return a;
+    a.style.visibility = 'hidden';
+    const {
+      fetchPlanOnePlans,
+      buildUrl,
+    } = await import('./utils/pricing.js');
+    const {
+      url,
+      country,
+      language,
+      offerId,
+    } = await fetchPlanOnePlans(a.href);
+    const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
+    const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
+    a.href = newTrialHref;
+  } catch (error) {
+    window.lana.log(`Failed to fetch prices for page plan: ${error}`);
+  }
+  a.style.visibility = 'visible';
+  return a;
+}
+
+function decorateCommerceLinks(area) {
+  const blocks = getMetadata('ax-commerce-override')?.toLowerCase()?.split(',') || [];
+  const selector = blocks.map((block) => `.${block} a`).join(', ');
+  selector && [...area.querySelectorAll(selector)].forEach((a) => {
+    formatDynamicCartLink(a);
+  });
+}
+
 export function decorateArea(area = document) {
   document.body.dataset.device = navigator.userAgent.includes('Mobile') ? 'mobile' : 'desktop';
   const selector = area === document ? 'main > div' : ':scope body > div';
@@ -775,4 +808,6 @@ export function decorateArea(area = document) {
   linksToNotAutoblock.forEach((link) => {
     if (!link.href.includes('#_dnb')) link.href = `${link.href}#_dnb`;
   });
+
+  decorateCommerceLinks(area);
 }

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -745,17 +745,10 @@ async function formatDynamicCartLink(a) {
     const pattern = /.*commerce.*adobe\.com.*/gm;
     if (!pattern.test(a.href)) return a;
     a.style.visibility = 'hidden';
-    const {
-      fetchPlanOnePlans,
-      buildUrl,
-    } = await import('./utils/pricing.js');
-    const {
-      url,
-      country,
-      language,
-      offerId,
-    } = await fetchPlanOnePlans(a.href);
-    const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
+    const [{ fetchPlanOnePlans, buildUrl }, { getConfig }] = await Promise.all([
+      import('./utils/pricing.js'), import(`${getLibs()}/utils/utils.js`),
+    ]);
+    const { url, country, language, offerId } = await fetchPlanOnePlans(a.href);
     const newTrialHref = buildUrl(url, country, language, getConfig, offerId);
     a.href = newTrialHref;
   } catch (error) {


### PR DESCRIPTION
Adds support of using page metadata to inject our dynamic commerce link logic into specified blocks.

Resolves: https://jira.corp.adobe.com/browse/MWPW-169944?filter=381833

How to test:
1. hit the branch url
2. dismiss the geo-routing modal
3. investigate the url of the first purple "Start 14-day free trial" CTA
4. it should have co=gb, compared to co=us as in stage/main

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/uk/express/business?country=gb&martech=off
- After: https://commerce-page-metadata--express-milo--adobecom.aem.page/uk/express/business?country=gb&martech=off
