### PR TITLE
[MWPW-167121][Login Page] Lower floating panel

### DIFF
--- a/express/code/blocks/floating-panel/floating-panel.css
+++ b/express/code/blocks/floating-panel/floating-panel.css
@@ -5,7 +5,7 @@
   box-shadow: 0px 0px 12px 0px rgba(0, 0, 0, 0.16);
   position: fixed;
   z-index: 2;
-  bottom: 100px;
+  bottom: 16px;
   box-sizing: border-box;
   width: 343px;
   left: 50%;
@@ -69,6 +69,5 @@
 }
 
 .floating-panel .floating-panel-link-row a.con-button {
-  /* min-width: 100px; */
   margin: 0;
 }

--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -4,10 +4,16 @@
     min-height: 462px;
 }
 
+.dialog-modal:has(.susi-light.tabs) {
+  width: 400px;
+  min-height: 462px;
+}
+
 .susi-light {
   display: flex;
   align-items: center;
   justify-content: center;
+  line-height: initial;
 }
 
 .susi-tabs {
@@ -105,6 +111,8 @@
 .susi-tabs .footer.susi-bubbles h2 {
   font-size: var(--body-font-size-l);
   font-weight: 700;
+  line-height: var(--heading-line-height);
+  margin: 0;
 }
 
 .susi-tabs .footer .susi-bubble-container {


### PR DESCRIPTION
Moves Floating Panel to be 16px above the bottom edge compared to 100px so it covers the less important footer rather than SUSI buttons.

Resolves: https://jira.corp.adobe.com/browse/MWPW-167121

How to test:

1. Use a real phone or emulate a mobile device using Chrome
2. Visit the url
3. You should see the panel floating closer to the bottom of the page

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/express/login?martech=off
- After: https://susi-light--express-milo--adobecom.aem.page/express/login?martech=off
