### PR TITLE
[MWPW-169645] Base QA Parameter Fix

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -91,7 +91,6 @@ function frictionlessQAExperiment(
       ccEverywhere.quickAction.removeBackground(docConfig, appConfig, exportConfig, contConfig);
       break;
     case 'qa-in-product-variant1':
-   //   appConfig.metaData.isFrictionlessQa = false;
       document.querySelector(`${globalNavSelector}.ready`).style.display = 'none';
       ccEverywhere.editor.createWithAsset(docConfig, appConfig, exportConfig, {
         ...contConfig,
@@ -99,7 +98,6 @@ function frictionlessQAExperiment(
       });
       break;
     case 'qa-in-product-variant2':
-    //  appConfig.metaData.isFrictionlessQa = false;
       document.querySelector(`${globalNavSelector}.ready`).style.display = 'none';
       ccEverywhere.editor.createWithAsset(docConfig, appConfig, exportConfig, {
         ...contConfig,

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -91,7 +91,7 @@ function frictionlessQAExperiment(
       ccEverywhere.quickAction.removeBackground(docConfig, appConfig, exportConfig, contConfig);
       break;
     case 'qa-in-product-variant1':
-      appConfig.metaData.isFrictionlessQa = false;
+   //   appConfig.metaData.isFrictionlessQa = false;
       document.querySelector(`${globalNavSelector}.ready`).style.display = 'none';
       ccEverywhere.editor.createWithAsset(docConfig, appConfig, exportConfig, {
         ...contConfig,
@@ -99,7 +99,7 @@ function frictionlessQAExperiment(
       });
       break;
     case 'qa-in-product-variant2':
-      appConfig.metaData.isFrictionlessQa = false;
+    //  appConfig.metaData.isFrictionlessQa = false;
       document.querySelector(`${globalNavSelector}.ready`).style.display = 'none';
       ccEverywhere.editor.createWithAsset(docConfig, appConfig, exportConfig, {
         ...contConfig,


### PR DESCRIPTION
Describe your specific features or fixes

Reverts a config change that prevented QA urls from being loaded on fricitonless QA pages

Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-169645

Test Instructions:

Visit the two URLs below and use the remove background feature. Once the background is removed, open the inspector and select the iframe containing the editor. You should see that the source of the iframe is https://12990.quick-actions-prenv.projectx.corp.adobe.com

instead of stage.adobe.com

<img width="377" alt="Screenshot 2025-03-21 at 10 57 12 AM" src="https://github.com/user-attachments/assets/0446bd6a-1b0b-43b9-bbae-d10711544469" />


Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- 
- After:  
- https://cc-everywhere-base-qa-fix--express-milo--adobecom.hlx.page/express/experiments/eric/rb001/remove-background?hzenv=stage&baseQA=https%3A%2F%2F129900.quick-actions-prenv.projectx.corp.adobe.com&variant=qa-in-product-control
- https://cc-everywhere-base-qa-fix--express-milo--adobecom.hlx.page/express/experiments/eric/rb001/remove-background?hzenv=stage&base=https%3A%2F%2F129900.quick-actions-prenv.projectx.corp.adobe.com&variant=qa-in-product-control
