### PR TITLE
[MWPW-170094] Hero Section logo Injection

### DIFF
--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -17,6 +17,7 @@ import {
   getMetadata,
   preDecorateSections,
   getRedirectUri,
+  getIconElementDeprecated,
 } from './utils.js';
 
 // Add project-wide style path here.
@@ -232,6 +233,11 @@ function decorateHeroLCP(loadStyle, config, createTag) {
         heroPicture.classList.add('hero-bg');
       } else {
         heroSection.classList.add('hero-noimage');
+      }
+      if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+        const logo = getIconElementDeprecated('adobe-express-logo');
+        logo.classList.add('express-logo');
+        heroSection.prepend(logo);
       }
     }
   } else if (template === 'blog' && h1 && getMetadata('author') && getMetadata('publication-date')) {

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -234,7 +234,7 @@ function decorateHeroLCP(loadStyle, config, createTag) {
       } else {
         heroSection.classList.add('hero-noimage');
       }
-      if (['on', 'yes'].includes(getMetadata('marquee-inject-logo')?.toLowerCase())) {
+      if (['on', 'yes'].includes(getMetadata('hero-inject-logo')?.toLowerCase())) {
         const logo = getIconElementDeprecated('adobe-express-logo');
         logo.classList.add('express-logo');
         heroSection.prepend(logo);

--- a/express/code/scripts/scripts.js
+++ b/express/code/scripts/scripts.js
@@ -234,7 +234,7 @@ function decorateHeroLCP(loadStyle, config, createTag) {
       } else {
         heroSection.classList.add('hero-noimage');
       }
-      if (['on', 'yes'].includes(getMetadata('hero-inject-logo')?.toLowerCase())) {
+      if (['on', 'yes'].includes(getMetadata('hero-inject-logo')?.toLowerCase()?.trim())) {
         const logo = getIconElementDeprecated('adobe-express-logo');
         logo.classList.add('express-logo');
         heroSection.prepend(logo);

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -556,6 +556,12 @@ main #hero .icon {
   width: 2em;
 }
 
+#hero .icon.express-logo {
+  width: initial;
+  height: 30px;
+  padding: 1rem 0 1rem;
+}
+
 main .icon.icon-cc-express-stacked,
 main .columns .icon.icon-cc-express-stacked {
   width: unset;


### PR DESCRIPTION
Adds a page metadata hero-inject-logo, that will inject express logo into the hero section (H1 but no blocks) of the page. This will be applied on https://www.adobe.com/express/ambassadors/list. The rationale behind the separation from marquee-inject-logo is to avoid impacting our blog pages, as marquee-inject-logo is on for most of our pages.

Resolves: https://jira.corp.adobe.com/browse/MWPW-170094

How to test:
- An Express logo should be visible on the feature branch link but not on stage

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/express/ambassadors/list
- After: https://hero-logo--express-milo--adobecom.aem.page/express/ambassadors/list?martech=off
