### PR TITLE
Authoring Enhancement Columns Block Header Size

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -33,21 +33,21 @@ main .section .ax-columns.enterprise .column h2 {
   font-size: 60px;
 }
 
-main .content.columns-medium-header h1,
-main .content.columns-medium-header h2,
-main .content.columns-medium-header h3,
-main .content.columns-medium-header h4,
-main .content.columns-medium-header h5,
-main .content.columns-medium-header h6 {
+.content.columns-medium-header h1,
+.content.columns-medium-header h2,
+.content.columns-medium-header h3,
+.content.columns-medium-header h4,
+.content.columns-medium-header h5,
+.content.columns-medium-header h6 {
   font-size: var(--heading-font-size-m);
 }
 
-main .content.columns-small-header h1,
-main .content.columns-small-header h2,
-main .content.columns-small-header h3,
-main .content.columns-small-header h4,
-main .content.columns-small-header h5,
-main .content.columns-small-header h6 {
+.content.columns-small-header h1,
+.content.columns-small-header h2,
+.content.columns-small-header h3,
+.content.columns-small-header h4,
+.content.columns-small-header h5,
+.content.columns-small-header h6 {
   font-size: var(--heading-font-size-s);
 }
 

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -33,8 +33,22 @@ main .section .ax-columns.enterprise .column h2 {
   font-size: 60px;
 }
 
-main .content.columns-header-small h3 {
-  font-size: 22px;
+main .content.columns-medium-header h1,
+main .content.columns-medium-header h2,
+main .content.columns-medium-header h3,
+main .content.columns-medium-header h4,
+main .content.columns-medium-header h5,
+main .content.columns-medium-header h6 {
+  font-size: var(--heading-font-size-m);
+}
+
+main .content.columns-small-header h1,
+main .content.columns-small-header h2,
+main .content.columns-small-header h3,
+main .content.columns-small-header h4,
+main .content.columns-small-header h5,
+main .content.columns-small-header h6 {
+  font-size: var(--heading-font-size-s);
 }
 
 .ax-columns {

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -33,6 +33,10 @@ main .section .ax-columns.enterprise .column h2 {
   font-size: 60px;
 }
 
+main .content.columns-header-small h3 {
+  font-size: 22px;
+}
+
 .ax-columns {
   padding-left: 15px;
   padding-right: 15px;
@@ -1288,4 +1292,3 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
 .ax-columns.slim-padding .column {
   padding: 20px;
 }
-

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -498,4 +498,14 @@ export default async function decorate(block) {
       });
     });
   }
+
+  if (block.classList.contains('small-header')) {
+    const parentDiv = block.parentElement;
+    if (parentDiv) {
+      const parentHeader = parentDiv.querySelector('h1, h2, h3, h4, h5, h6');
+      if (parentHeader) {
+        parentHeader.parentElement.classList.add('columns-header-small');
+      }
+    }
+  }
 }

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -179,6 +179,16 @@ const decoratePrimaryCTARow = (rowNum, cellNum, cell) => {
   content.parentElement.prepend(links[0]);
 };
 
+function addHeaderClass(block, size) {
+  const parentDiv = block.parentElement;
+  if (parentDiv) {
+    const parentHeader = parentDiv.querySelector('h1, h2, h3, h4, h5, h6');
+    if (parentHeader) {
+      parentHeader.parentElement.classList.add(`columns-${size}-header`);
+    }
+  }
+}
+
 export default async function decorate(block) {
   await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
     ({ createTag, getMetadata, getConfig } = utils);
@@ -500,12 +510,10 @@ export default async function decorate(block) {
   }
 
   if (block.classList.contains('small-header')) {
-    const parentDiv = block.parentElement;
-    if (parentDiv) {
-      const parentHeader = parentDiv.querySelector('h1, h2, h3, h4, h5, h6');
-      if (parentHeader) {
-        parentHeader.parentElement.classList.add('columns-header-small');
-      }
-    }
+    addHeaderClass(block, 'small');
+  }
+
+  if (block.classList.contains('medium-header')) {
+    addHeaderClass(block, 'medium');
   }
 }


### PR DESCRIPTION
Describe your specific features or fixes:
* Allow authors to use a 22px or 28px header for the columns block

Resolves: [MWPW-159047](https://jira.corp.adobe.com/browse/MWPW-159047)
22px Header
<img width="482" alt="22px Header" src="https://github.com/user-attachments/assets/4434d0e9-27b3-4724-9aa5-e343fb31bdb4" />
28px Header
<img width="478" alt="28px Header" src="https://github.com/user-attachments/assets/64628cb1-2bcb-400a-bef3-9d4f556ff447" />

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://milo-columns-enhancement--express-milo--adobecom.aem.page/drafts/jsandlan/milo-columns-header-enhancement
