### PR TITLE
[MWPW-169165] Grid marquee labels update for MAX

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -188,14 +188,14 @@ main .section .grid-marquee h1 {
   justify-content: space-between;
 }
 
-.grid-marquee .panel .drawer-cta:hover {
-  text-decoration: underline;
-}
-
 .grid-marquee .panel .drawer-cta .text-group {
   display: flex;
   gap: 16px;
   align-items: center;
+}
+
+.grid-marquee .panel .drawer-cta:hover .text-group {
+  text-decoration: underline;
 }
 
 .grid-marquee .grid-marquee-label {

--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -146,6 +146,10 @@ main .section .grid-marquee h1 {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: sticky;
+  top: 0;
+  background-color: var(--color-white);
+  border-bottom: 1px solid #0000001a;
 }
 
 .grid-marquee .drawer .title-row strong {
@@ -156,7 +160,6 @@ main .section .grid-marquee h1 {
   /* override browser button style */
   border: 0;
   margin: auto;
-  border-top: 1px solid #0000001A;
   display: flex;
   justify-content: center;
   width: 100%;

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -13,10 +13,10 @@ function drawerOff() {
   currDrawer.classList.add('hide');
   currDrawer.querySelector('video')?.pause()?.catch(() => {});
   currDrawer = null;
-  document.body.classList.remove('disable-scroll');
+  if (!largeMQ.matches) document.body.classList.remove('disable-scroll');
 }
 function drawerOn(drawer) {
-  document.body.classList.add('disable-scroll');
+  drawerOff();
   drawer.closest('.card').setAttribute('aria-expanded', true);
   drawer.classList.remove('hide');
   const video = drawer.querySelector('video');
@@ -25,7 +25,7 @@ function drawerOn(drawer) {
     video.play().catch(() => {});
   }
   currDrawer = drawer;
-  drawerOff();
+  if (!largeMQ.matches) document.body.classList.add('disable-scroll');
 }
 document.addEventListener('click', (e) => currDrawer && !currDrawer.closest('.card').contains(e.target) && drawerOff());
 let isTouch;

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -13,9 +13,10 @@ function drawerOff() {
   currDrawer.classList.add('hide');
   currDrawer.querySelector('video')?.pause()?.catch(() => {});
   currDrawer = null;
+  document.body.classList.remove('disable-scroll');
 }
 function drawerOn(drawer) {
-  drawerOff();
+  document.body.classList.add('disable-scroll');
   drawer.closest('.card').setAttribute('aria-expanded', true);
   drawer.classList.remove('hide');
   const video = drawer.querySelector('video');
@@ -24,6 +25,7 @@ function drawerOn(drawer) {
     video.play().catch(() => {});
   }
   currDrawer = drawer;
+  drawerOff();
 }
 document.addEventListener('click', (e) => currDrawer && !currDrawer.closest('.card').contains(e.target) && drawerOff());
 let isTouch;


### PR DESCRIPTION
Following the comments in the ticket:
- no more underlined label
- disabled scrolling on mobile and tablet when a card is up
- sticky title and X button

Resolves: https://jira.corp.adobe.com/browse/MWPW-169165

How to test:
- Use mobile setup, and click the second card on the first row
- Scroll on the background, it should be disabled now
- Scroll inside the card, the title row including the X button should be sticky now
- Use desktop setup, and hover onto the links. Labels themselves should no longer be underlined

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.live/drafts/jingle/?martech=off
- After: https://grid-marquee-labels-update--express-milo--adobecom.aem.live/drafts/jingle/?martech=off
