### PR TITLE
[Eng Enhancements] Why Choose Express Page - Default Toggle Teams first

### DIFF
--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -74,9 +74,11 @@ function initButton($block, $sections, index) {
       }, 16);
     });
 
-    const shouldSelectFirst = $enclosingMain.querySelector('[data-select-first]');
-    console.log('shouldSelectFirst', shouldSelectFirst);
-    if (index === (shouldSelectFirst ? 0 : 1)) {
+    const toggleDefaultOption = $enclosingMain.querySelector('[data-toggle-default]');
+    const defaultValue = toggleDefaultOption?.dataset.toggleDefault || toggleDefaultOption?.getAttribute('data-toggle-default');
+    const defaultIndex = parseInt(defaultValue, 10) - 1;
+
+    if (index === (defaultIndex || 1)) {
       $buttons[index].classList.add('active');
       const resizeObserver = new ResizeObserver(() => {
         updateBackgroundSize();

--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -74,7 +74,9 @@ function initButton($block, $sections, index) {
       }, 16);
     });
 
-    if (index === 1) {
+    const shouldSelectFirst = $enclosingMain.querySelector('[data-select-first]');
+    console.log('shouldSelectFirst', shouldSelectFirst);
+    if (index === (shouldSelectFirst ? 0 : 1)) {
       $buttons[index].classList.add('active');
       const resizeObserver = new ResizeObserver(() => {
         updateBackgroundSize();

--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -74,9 +74,12 @@ function initButton($block, $sections, index) {
       }, 16);
     });
 
-    if (index === 0) {
+    if (index === 1) {
       $buttons[index].classList.add('active');
-      updateBackgroundSize();
+      const resizeObserver = new ResizeObserver(() => {
+        updateBackgroundSize();
+      });
+      resizeObserver.observe($buttons[index]);
     }
 
     $buttons[index].addEventListener('click', () => {


### PR DESCRIPTION
Describe your specific features or fixes:
* Allow authors to control whether the first or second option in the content-toggle is selected on page load

Resolves: [MWPW-170412](https://jira.corp.adobe.com/browse/MWPW-170412)

Authoring Example: [Allow Default Content Toggle](https://adobe.sharepoint.com/:w:/r/sites/adobecom/Express/website/drafts/jsandlan/milo-allow-content-toggle.docx?d=w126dc52793024d8581e9f267dd119671&csf=1&web=1&e=IZRYMI)
<img width="664" alt="content" src="https://github.com/user-attachments/assets/5749f76e-8d45-403a-90d5-d1ee7e942068" />

Authors have selected the second option and as a result on page load - the second option is selected: 
<img width="1277" alt="content-toggle" src="https://github.com/user-attachments/assets/ee587be8-9d39-4bd4-8225-df22646bb84f" />

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/why-choose-express
- After: https://milo-allow-content-toggle--express-milo--adobecom.aem.page/drafts/jsandlan/milo-allow-content-toggle