### PR TITLE
Padding Issue For Right Toggle Button When Window Resized

### DIFF
--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -51,29 +51,6 @@ function initButton($block, $sections, index) {
       });
     };
 
-    let resizeTimeout;
-    window.addEventListener('resize', () => {
-      clearTimeout(resizeTimeout);
-      resizeTimeout = setTimeout(() => {
-        const activeButton = $block.querySelector('button.active');
-        if (activeButton) {
-          const buttonWidth = activeButton.getBoundingClientRect().width + 5;
-          let leftOffset = 0;
-
-          Array.from($buttons).forEach((btn, i) => {
-            if (btn === activeButton) {
-              leftOffset += i * 10;
-            } else if (Array.from($buttons).indexOf(activeButton) > i) {
-              leftOffset += btn.getBoundingClientRect().width + 10;
-            }
-          });
-
-          $toggleBackground.style.left = `${leftOffset}px`;
-          $toggleBackground.style.width = `${buttonWidth}px`;
-        }
-      }, 16);
-    });
-
     if (index === 0) {
       $buttons[index].classList.add('active');
       updateBackgroundSize();


### PR DESCRIPTION
Describe your specific features or fixes:
* Prevents the right-side white highlight of the content-toggle button from extending past its right side boundary when browser window is expanded

**Before**:
<img width="1249" alt="before" src="https://github.com/user-attachments/assets/b6f37cf7-d3a9-4e17-b50a-e6c886f2bd86" />

**After**:
<img width="1565" alt="content-toggle" src="https://github.com/user-attachments/assets/eff9740b-82c7-438a-a17c-8516bd0f70f0" />

Resolves: [MWPW-170464](https://jira.corp.adobe.com/browse/MWPW-170464)

No Authoring Changes: [Allow Default Content Toggle](https://adobe.sharepoint.com/:w:/r/sites/adobecom/Express/website/drafts/jsandlan/milo-allow-content-toggle.docx?d=w126dc52793024d8581e9f267dd119671&csf=1&web=1&e=IZRYMI)

Test URLs:
- Pre Migration Link: https://adobe.com/express/business
- Before: https://main--express-milo--adobecom.aem.page/express/business
- After: https://content-toggle-resize--express-milo--adobecom.aem.page/drafts/jsandlan/milo-allow-content-toggle
