### PR TITLE
[Eng Enhancements] Why Choose Express Page - Default Toggle Content Correct On Page Load

### DIFF
--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -26,6 +26,15 @@ function decorateButton($block, $toggle) {
   $block.append($button);
 }
 
+function getDefatultToggleIndex($block) {
+  const $enclosingMain = $block.closest('main');
+  const toggleDefaultOption = $enclosingMain.querySelector('[data-toggle-default]');
+  const defaultValue = toggleDefaultOption?.dataset.toggleDefault || toggleDefaultOption?.getAttribute('data-toggle-default');
+  const parsedIndex = parseInt(defaultValue, 10);
+  const defaultIndex = !defaultValue || Number.isNaN(parsedIndex) ? 1 : parsedIndex - 1;
+  return defaultIndex;
+}
+
 function initButton($block, $sections, index) {
   const $enclosingMain = $block.closest('main');
 
@@ -68,11 +77,7 @@ function initButton($block, $sections, index) {
       updateBackgroundSize(newIndex);
     };
 
-    const toggleDefaultOption = $enclosingMain.querySelector('[data-toggle-default]');
-    const defaultValue = toggleDefaultOption?.dataset.toggleDefault || toggleDefaultOption?.getAttribute('data-toggle-default');
-    const defaultIndex = parseInt(defaultValue, 10) - 1;
-
-    if (index === (defaultIndex || 1)) {
+    if (index === getDefatultToggleIndex($block)) {
       setActiveButton(index);
     }
 
@@ -142,7 +147,7 @@ export default async function decorate(block) {
 
     if ($sections) {
       $sections.forEach(($section, index) => {
-        if (index > 0) {
+        if (index !== getDefatultToggleIndex(block)) {
           $section.style.display = 'none';
         }
       });

--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -72,7 +72,7 @@ function initButton($block, $sections, index) {
     const defaultValue = toggleDefaultOption?.dataset.toggleDefault || toggleDefaultOption?.getAttribute('data-toggle-default');
     const defaultIndex = parseInt(defaultValue, 10) - 1;
 
-    if (index === (defaultIndex || 0)) {
+    if (index === (defaultIndex || 1)) {
       setActiveButton(index);
     }
 


### PR DESCRIPTION
Describe your specific features or fixes:
* Ensures the pricing table below the content-toggle is set to the correct content on page load

Resolves: [MWPW-170412](https://jira.corp.adobe.com/browse/MWPW-170412)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/why-choose-express
- After: https://content-toggle-content-switch--express-milo--adobecom.aem.page/drafts/jsandlan/milo-allow-content-toggle/
