### PR TITLE
Separate grid marquee ratings

### DIFF
--- a/express/code/blocks/app-ratings/app-ratings.css
+++ b/express/code/blocks/app-ratings/app-ratings.css
@@ -60,3 +60,8 @@
   }
  
 }
+
+
+.sr-text
+
+{ position: absolute; clip: rect(1px, 1px, 1px, 1px); -webkit-clip-path: inset(50%) ; clip-path: inset(50%); padding: 0; border: 0; height: 1px; width: 1px; white-space: nowrap; overflow: hidden; }

--- a/express/code/blocks/app-ratings/app-ratings.css
+++ b/express/code/blocks/app-ratings/app-ratings.css
@@ -2,11 +2,9 @@
   max-width: initial;
   text-align: center;
   display: flex;
-  padding: 8px 16px;
   justify-content: center;
   align-items: center;
-  align-content: center;
-  gap: 16px 48px;
+  align-content: center; 
   align-self: stretch;
   flex-wrap: wrap; 
 }
@@ -46,12 +44,10 @@
 @media screen and (min-width: 768px) {
   .app-ratings .ratings {
     flex-direction: row;
-    padding: 0;
+    padding :  16px 32px;
     gap: 48px;
   }
-  .app-ratings {
-    padding : 32px 0px;
-  }
+ 
 }
 
 @media screen and (min-width: 1280px) {
@@ -60,8 +56,3 @@
   }
  
 }
-
-
-.sr-text
-
-{ position: absolute; clip: rect(1px, 1px, 1px, 1px); -webkit-clip-path: inset(50%) ; clip-path: inset(50%); padding: 0; border: 0; height: 1px; width: 1px; white-space: nowrap; overflow: hidden; }

--- a/express/code/blocks/app-ratings/app-ratings.css
+++ b/express/code/blocks/app-ratings/app-ratings.css
@@ -1,0 +1,59 @@
+.app-ratings {
+  max-width: initial;
+  text-align: center;
+  display: flex;
+  padding: 8px 16px;
+  justify-content: center;
+  align-items: center;
+  align-content: center;
+  gap: 16px 48px;
+  align-self: stretch;
+  flex-wrap: wrap; 
+}
+
+.app-ratings strong,
+.app-ratings a,
+.app-ratings button {
+  font-family: var(--body-font-family);
+}
+
+.app-ratings .ratings {
+  display: flex;
+  min-width: var(--Global-Device-Widths-device-min-width, 360px);
+  max-width: var(--Global-Device-Widths-device-max-width, 767px);
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: var(--Marquee-grid-Card-Element-Padding, 24px);
+  align-self: stretch;
+  padding: 16px;
+}
+
+.app-ratings .ratings-container {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.app-ratings .ratings img {
+  height: 35px;
+  padding-left: 12px;
+  margin: 0;
+}
+
+@media screen and (min-width: 768px) {
+  .app-ratings .ratings {
+    flex-direction: row;
+    padding: 0;
+  }
+  .app-ratings {
+    padding : 32px 0px;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .app-ratings {
+    padding : 16px 0px;
+  }
+ 
+}

--- a/express/code/blocks/app-ratings/app-ratings.css
+++ b/express/code/blocks/app-ratings/app-ratings.css
@@ -24,7 +24,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: var(--Marquee-grid-Card-Element-Padding, 24px);
+  gap: var(--Marquee-grid-Card-Element-Padding, 16px);
   align-self: stretch;
   padding: 16px;
 }
@@ -37,14 +37,17 @@
 
 .app-ratings .ratings img {
   height: 35px;
-  padding-left: 12px;
-  margin: 0;
+    padding-left: 12px;
+    margin: 0;
+    position: relative;
+    top: 2px;
 }
 
 @media screen and (min-width: 768px) {
   .app-ratings .ratings {
     flex-direction: row;
     padding: 0;
+    gap: 48px;
   }
   .app-ratings {
     padding : 32px 0px;

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -6,8 +6,7 @@ let getConfig;
 const APPLE = 'apple';
 const GOOGLE = 'google';
 
-async function makeRating(store, ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder) {
-
+async function makeRating(store, ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder) {
   const ratings = ratingPlaceholder?.split(';') || [];
   const link = ratings[2]?.trim();
   if (!link) {
@@ -30,15 +29,15 @@ async function makeRating(store, ratingPlaceholder,starsPlaceholder,playStoreLab
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 
-async function makeRatings(ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder) {
+async function makeRatings(ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder) {
   const ratings = createTag('div', { class: 'ratings' });
   const userAgent = getMobileOperatingSystem();
   if (userAgent !== 'Android') {
-    const appleElement = await makeRating('apple',ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder);
+    const appleElement = await makeRating('apple', ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder);
     appleElement && ratings.append(appleElement);
   }
   if (userAgent !== 'iOS') {
-    const googleElement = await makeRating('google',ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder);
+    const googleElement = await makeRating('google', ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder);
     googleElement && ratings.append(googleElement);
   }
   return ratings;
@@ -51,12 +50,12 @@ export default async function decorate(block) {
     starsPlaceholder,
     playStoreLabelPlaceholder,
     appleStoreLabelPlaceholder] = await Promise.all(
-      [
-        replaceKey('app-store-ratings', getConfig()),
-        replaceKey('app-store-stars', getConfig()),
-        replaceKey('app-store-ratings-play-store', getConfig()),
-        replaceKey('app-store-ratings-apple-store', getConfig()),
-      ],
-    );
-  block.append(await makeRatings(ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder));
+    [
+      replaceKey('app-store-ratings', getConfig()),
+      replaceKey('app-store-stars', getConfig()),
+      replaceKey('app-store-ratings-play-store', getConfig()),
+      replaceKey('app-store-ratings-apple-store', getConfig()),
+    ],
+  );
+  block.append(await makeRatings(ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder));
 }

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -37,7 +37,6 @@ async function makeRating(store) {
   const star = getIconElementDeprecated('star');
   star.setAttribute('alt', starsPlaceholder);
   star.setAttribute('role', 'img');
-  star.setAttribute('aria-hidden', 'true');
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -35,8 +35,6 @@ async function makeRating(store) {
   const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
   await trackBranchParameters([storeLink]);
 
-  const ratingsContainerAria = score + " " + starsPlaceholder + " " + cnt; 
-
   const star = getIconElementDeprecated('star');
   star.setAttribute('role', 'img')
   star.setAttribute('aria-label', starsPlaceholder);

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -35,7 +35,8 @@ async function makeRating(store) {
   const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
   await trackBranchParameters([storeLink]);
   const star = getIconElementDeprecated('star');
-  star.setAttribute('alt', starsPlaceholder);
+  star.setAttribute('aria-label', starsPlaceholder);
+  star.setAttribute('role', 'img');
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -6,7 +6,13 @@ let getConfig;
 const APPLE = 'apple';
 const GOOGLE = 'google';
 
-async function makeRating(store, ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder) {
+async function makeRating(
+  store,
+  ratingPlaceholder,
+  starsPlaceholder,
+  playStoreLabelPlaceholder,
+  appleStoreLabelPlaceholder,
+) {
   const ratings = ratingPlaceholder?.split(';') || [];
   const link = ratings[2]?.trim();
   if (!link) {
@@ -29,15 +35,32 @@ async function makeRating(store, ratingPlaceholder, starsPlaceholder, playStoreL
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 
-async function makeRatings(ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder) {
+async function makeRatings(
+  ratingPlaceholder,
+  starsPlaceholder,
+  playStoreLabelPlaceholder,
+  appleStoreLabelPlaceholder,
+) {
   const ratings = createTag('div', { class: 'ratings' });
   const userAgent = getMobileOperatingSystem();
   if (userAgent !== 'Android') {
-    const appleElement = await makeRating('apple', ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder);
+    const appleElement = await makeRating(
+      'apple',
+      ratingPlaceholder,
+      starsPlaceholder,
+      playStoreLabelPlaceholder,
+      appleStoreLabelPlaceholder,
+    );
     appleElement && ratings.append(appleElement);
   }
   if (userAgent !== 'iOS') {
-    const googleElement = await makeRating('google', ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder);
+    const googleElement = await makeRating(
+      'google',
+      ratingPlaceholder,
+      starsPlaceholder,
+      playStoreLabelPlaceholder,
+      appleStoreLabelPlaceholder,
+    );
     googleElement && ratings.append(googleElement);
   }
   return ratings;
@@ -57,5 +80,10 @@ export default async function decorate(block) {
       replaceKey('app-store-ratings-apple-store', getConfig()),
     ],
   );
-  block.append(await makeRatings(ratingPlaceholder, starsPlaceholder, playStoreLabelPlaceholder, appleStoreLabelPlaceholder));
+  block.append(await makeRatings(
+    ratingPlaceholder,
+    starsPlaceholder,
+    playStoreLabelPlaceholder,
+    appleStoreLabelPlaceholder,
+  ));
 }

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -17,7 +17,6 @@ async function makeRating(store) {
         await replaceKey('app-store-ratings-apple-store', getConfig()) 
       ]
     )
-
     const ratings = ratingPlaceholder?.split(';') || []; 
     const link = ratings[2]?.trim();
     if (!link) {
@@ -34,6 +33,8 @@ async function makeRating(store) {
     await trackBranchParameters([storeLink]);
     const star =  getIconElementDeprecated('star')
     star.setAttribute('alt', starsPlaceholder)
+    star.setAttribute('role', 'img')
+    star.setAttribute('aria-hidden', 'true')
     return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
   }
   
@@ -41,11 +42,11 @@ async function makeRating(store) {
     const ratings = createTag('div', { class: 'ratings' });
     const userAgent = getMobileOperatingSystem();
     const cb = (el) => el && ratings.append(el);
-    console.log(userAgent)
-    // eslint-disable-next-line chai-friendly/no-unused-expressions
-    userAgent !== 'Android' && makeRating('apple').then(cb);
     // eslint-disable-next-line chai-friendly/no-unused-expressions
     userAgent !== 'iOS' && makeRating('google').then(cb);
+    // eslint-disable-next-line chai-friendly/no-unused-expressions
+    userAgent !== 'Android' && makeRating('apple').then(cb);
+   
     return ratings;
   }
   

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -38,14 +38,9 @@ async function makeRating(store) {
   const ratingsContainerAria = score + " " + starsPlaceholder + " " + cnt; 
 
   const star = getIconElementDeprecated('star');
+  star.setAttribute('role', 'img')
   star.setAttribute('aria-label', starsPlaceholder);
-  star.setAttribute('role', 'img');
-  star.setAttribute('aria-hidden' , 'true')
-  const b = createTag('div', { class: 'ratings-container'}, [score, star, cnt]);
-  b.setAttribute('role', 'status')
-  b.setAttribute('aria-label', ratingsContainerAria);
-  const a = createTag('div' , { class :"ratings-container"}, [b, storeLink])
-  return a
+  return  createTag('div', { class: 'ratings-container'}, [score, star, cnt, storeLink]);
 }
 
 async function makeRatings() {

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -1,0 +1,55 @@
+import { getLibs, getMobileOperatingSystem, getIconElementDeprecated } from '../../scripts/utils.js';
+
+let createTag;
+let getConfig;
+
+const APPLE ='apple'
+const GOOGLE = 'google' 
+
+async function makeRating(store) {
+    const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
+
+    const [ratingPlaceholder, starsPlaceholder, playStorePlaceholder, appleStorePlaeholder] = await Promise.all(
+      [
+        await replaceKey('app-store-ratings', getConfig()),
+        await replaceKey('app-store-stars', getConfig()),
+        await replaceKey('app-store-ratings-play-store', getConfig()),
+        await replaceKey('app-store-ratings-apple-store', getConfig()) 
+      ]
+    )
+
+    const ratings = ratingPlaceholder?.split(';') || []; 
+    const link = ratings[2]?.trim();
+    if (!link) {
+      return null;
+    }
+
+    const storeTypeIndex = [APPLE, GOOGLE].indexOf(store);
+    const [score, cnt] = ratings[storeTypeIndex].split(',').map((str) => str.trim());
+    const ariaLabel = store === APPLE ? appleStorePlaeholder : playStorePlaceholder
+    const storeLink = createTag('a', { href: link ,
+     }, getIconElementDeprecated(`${store}-store`));  
+     storeLink.setAttribute('aria-label', ariaLabel)
+    const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
+    await trackBranchParameters([storeLink]);
+    const star =  getIconElementDeprecated('star')
+    star.setAttribute('alt', starsPlaceholder)
+    return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
+  }
+  
+  function makeRatings() {
+    const ratings = createTag('div', { class: 'ratings' });
+    const userAgent = getMobileOperatingSystem();
+    const cb = (el) => el && ratings.append(el);
+    console.log(userAgent)
+    // eslint-disable-next-line chai-friendly/no-unused-expressions
+    userAgent !== 'Android' && makeRating('apple').then(cb);
+    // eslint-disable-next-line chai-friendly/no-unused-expressions
+    userAgent !== 'iOS' && makeRating('google').then(cb);
+    return ratings;
+  }
+  
+  export default async function decorate(block) {
+    ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
+    block.append(makeRatings());
+  }

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -36,9 +36,9 @@ async function makeRating(store) {
   await trackBranchParameters([storeLink]);
 
   const star = getIconElementDeprecated('star');
-  star.setAttribute('role', 'img')
+  star.setAttribute('role', 'img');
   star.setAttribute('aria-label', starsPlaceholder);
-  return  createTag('div', { class: 'ratings-container'}, [score, star, cnt, storeLink]);
+  return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 
 async function makeRatings() {

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -3,54 +3,59 @@ import { getLibs, getMobileOperatingSystem, getIconElementDeprecated } from '../
 let createTag;
 let getConfig;
 
-const APPLE ='apple'
-const GOOGLE = 'google' 
+const APPLE = 'apple';
+const GOOGLE = 'google';
 
 async function makeRating(store) {
-    const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
+  const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
 
-    const [ratingPlaceholder, starsPlaceholder, playStorePlaceholder, appleStorePlaeholder] = await Promise.all(
-      [
-        await replaceKey('app-store-ratings', getConfig()),
-        await replaceKey('app-store-stars', getConfig()),
-        await replaceKey('app-store-ratings-play-store', getConfig()),
-        await replaceKey('app-store-ratings-apple-store', getConfig()) 
-      ]
-    )
-    const ratings = ratingPlaceholder?.split(';') || []; 
-    const link = ratings[2]?.trim();
-    if (!link) {
-      return null;
-    }
+  const [ratingPlaceholder,
+    starsPlaceholder,
+    playStorePlaceholder,
+    appleStorePlaeholder] = await Promise.all(
+    [
+      await replaceKey('app-store-ratings', getConfig()),
+      await replaceKey('app-store-stars', getConfig()),
+      await replaceKey('app-store-ratings-play-store', getConfig()),
+      await replaceKey('app-store-ratings-apple-store', getConfig()),
+    ],
+  );
+  const ratings = ratingPlaceholder?.split(';') || [];
+  const link = ratings[2]?.trim();
+  if (!link) {
+    return null;
+  }
 
-    const storeTypeIndex = [APPLE, GOOGLE].indexOf(store);
-    const [score, cnt] = ratings[storeTypeIndex].split(',').map((str) => str.trim());
-    const ariaLabel = store === APPLE ? appleStorePlaeholder : playStorePlaceholder
-    const storeLink = createTag('a', { href: link ,
-     }, getIconElementDeprecated(`${store}-store`));  
-     storeLink.setAttribute('aria-label', ariaLabel)
-    const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
-    await trackBranchParameters([storeLink]);
-    const star =  getIconElementDeprecated('star')
-    star.setAttribute('alt', starsPlaceholder)
-    star.setAttribute('role', 'img')
-    star.setAttribute('aria-hidden', 'true')
-    return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
+  const storeTypeIndex = [APPLE, GOOGLE].indexOf(store);
+  const [score, cnt] = ratings[storeTypeIndex].split(',').map((str) => str.trim());
+  const ariaLabel = store === APPLE ? appleStorePlaeholder : playStorePlaceholder;
+  const storeLink = createTag('a', { href: link,
+  }, getIconElementDeprecated(`${store}-store`));
+  storeLink.setAttribute('aria-label', ariaLabel);
+  const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
+  await trackBranchParameters([storeLink]);
+  const star = getIconElementDeprecated('star');
+  star.setAttribute('alt', starsPlaceholder);
+  star.setAttribute('role', 'img');
+  star.setAttribute('aria-hidden', 'true');
+  return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
+}
+
+async function makeRatings() {
+  const ratings = createTag('div', { class: 'ratings' });
+  const userAgent = getMobileOperatingSystem();
+  if (userAgent !== 'Android') {
+    const appleElement = await makeRating('apple');
+    appleElement && ratings.append(appleElement);
   }
-  
-  function makeRatings() {
-    const ratings = createTag('div', { class: 'ratings' });
-    const userAgent = getMobileOperatingSystem();
-    const cb = (el) => el && ratings.append(el);
-    // eslint-disable-next-line chai-friendly/no-unused-expressions
-    userAgent !== 'iOS' && makeRating('google').then(cb);
-    // eslint-disable-next-line chai-friendly/no-unused-expressions
-    userAgent !== 'Android' && makeRating('apple').then(cb);
-   
-    return ratings;
+  if (userAgent !== 'iOS') {
+    const googleElement = await makeRating('google');
+    googleElement && ratings.append(googleElement);
   }
-  
-  export default async function decorate(block) {
-    ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
-    block.append(makeRatings());
-  }
+  return ratings;
+}
+
+export default async function decorate(block) {
+  ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
+  block.append(await makeRatings());
+}

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -34,10 +34,18 @@ async function makeRating(store) {
   storeLink.setAttribute('aria-label', ariaLabel);
   const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
   await trackBranchParameters([storeLink]);
+
+  const ratingsContainerAria = score + " " + starsPlaceholder + " " + cnt; 
+
   const star = getIconElementDeprecated('star');
   star.setAttribute('aria-label', starsPlaceholder);
   star.setAttribute('role', 'img');
-  return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
+  star.setAttribute('aria-hidden' , 'true')
+  const b = createTag('div', { class: 'ratings-container'}, [score, star, cnt]);
+  b.setAttribute('role', 'status')
+  b.setAttribute('aria-label', ratingsContainerAria);
+  const a = createTag('div' , { class :"ratings-container"}, [b, storeLink])
+  return a
 }
 
 async function makeRatings() {

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -36,7 +36,6 @@ async function makeRating(store) {
   await trackBranchParameters([storeLink]);
   const star = getIconElementDeprecated('star');
   star.setAttribute('alt', starsPlaceholder);
-  star.setAttribute('role', 'img');
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -6,20 +6,8 @@ let getConfig;
 const APPLE = 'apple';
 const GOOGLE = 'google';
 
-async function makeRating(store) {
-  const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
+async function makeRating(store, ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder) {
 
-  const [ratingPlaceholder,
-    starsPlaceholder,
-    playStorePlaceholder,
-    appleStorePlaeholder] = await Promise.all(
-    [
-      await replaceKey('app-store-ratings', getConfig()),
-      await replaceKey('app-store-stars', getConfig()),
-      await replaceKey('app-store-ratings-play-store', getConfig()),
-      await replaceKey('app-store-ratings-apple-store', getConfig()),
-    ],
-  );
   const ratings = ratingPlaceholder?.split(';') || [];
   const link = ratings[2]?.trim();
   if (!link) {
@@ -28,8 +16,9 @@ async function makeRating(store) {
 
   const storeTypeIndex = [APPLE, GOOGLE].indexOf(store);
   const [score, cnt] = ratings[storeTypeIndex].split(',').map((str) => str.trim());
-  const ariaLabel = store === APPLE ? appleStorePlaeholder : playStorePlaceholder;
-  const storeLink = createTag('a', { href: link,
+  const ariaLabel = store === APPLE ? appleStoreLabelPlaceholder : playStoreLabelPlaceholder;
+  const storeLink = createTag('a', {
+    href: link,
   }, getIconElementDeprecated(`${store}-store`));
   storeLink.setAttribute('aria-label', ariaLabel);
   const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
@@ -41,15 +30,15 @@ async function makeRating(store) {
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 
-async function makeRatings() {
+async function makeRatings(ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder) {
   const ratings = createTag('div', { class: 'ratings' });
   const userAgent = getMobileOperatingSystem();
   if (userAgent !== 'Android') {
-    const appleElement = await makeRating('apple');
+    const appleElement = await makeRating('apple',ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder);
     appleElement && ratings.append(appleElement);
   }
   if (userAgent !== 'iOS') {
-    const googleElement = await makeRating('google');
+    const googleElement = await makeRating('google',ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder);
     googleElement && ratings.append(googleElement);
   }
   return ratings;
@@ -57,5 +46,17 @@ async function makeRatings() {
 
 export default async function decorate(block) {
   ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
-  block.append(await makeRatings());
+  const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
+  const [ratingPlaceholder,
+    starsPlaceholder,
+    playStoreLabelPlaceholder,
+    appleStoreLabelPlaceholder] = await Promise.all(
+      [
+        replaceKey('app-store-ratings', getConfig()),
+        replaceKey('app-store-stars', getConfig()),
+        replaceKey('app-store-ratings-play-store', getConfig()),
+        replaceKey('app-store-ratings-apple-store', getConfig()),
+      ],
+    );
+  block.append(await makeRatings(ratingPlaceholder,starsPlaceholder,playStoreLabelPlaceholder,appleStoreLabelPlaceholder));
 }

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -258,7 +258,7 @@ export default async function init(el) {
   const cards = items.map((item) => toCard(item));
   const cardsContainer = createTag('div', { class: 'cards-container' }, cards.map(({ card }) => card));
   [...cardsContainer.querySelectorAll('p:empty')].forEach((p) => p.remove());
-  foreground.append(logo, decorateHeadline(headline), cardsContainer, ...(el.classList.contains('ratings') ? [makeRatings()] : []));
+  foreground.append(logo, decorateHeadline(headline), cardsContainer, ...(el.classList.contains('ratings') ? [await makeRatings()] : []));
   background.classList.add('background');
   el.append(foreground);
   new IntersectionObserver((entries, ob) => {

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -2,6 +2,9 @@ import { getLibs, yieldToMain, getMobileOperatingSystem, getIconElementDeprecate
 
 let createTag; let getConfig;
 
+const APPLE = 'apple';
+const GOOGLE = 'google';
+
 let currDrawer = null;
 const largeMQ = window.matchMedia('(min-width: 1280px)');
 const mediumMQ = window.matchMedia('(min-width: 768px)');
@@ -199,28 +202,52 @@ function decorateHeadline(headline) {
 
 async function makeRating(store) {
   const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
-  const ratings = (await replaceKey('app-store-ratings', getConfig()))?.split(';') || [];
+
+  const [ratingPlaceholder,
+    starsPlaceholder,
+    playStorePlaceholder,
+    appleStorePlaeholder] = await Promise.all(
+    [
+      await replaceKey('app-store-ratings', getConfig()),
+      await replaceKey('app-store-stars', getConfig()),
+      await replaceKey('app-store-ratings-play-store', getConfig()),
+      await replaceKey('app-store-ratings-apple-store', getConfig()),
+    ],
+  );
+  const ratings = ratingPlaceholder?.split(';') || [];
   const link = ratings[2]?.trim();
   if (!link) {
     return null;
   }
-  const [score, cnt] = ratings[['apple', 'google'].indexOf(store)].split(',').map((str) => str.trim());
-  const storeLink = createTag('a', { href: link }, getIconElementDeprecated(`${store}-store`));
+
+  const storeTypeIndex = [APPLE, GOOGLE].indexOf(store);
+  const [score, cnt] = ratings[storeTypeIndex].split(',').map((str) => str.trim());
+  const ariaLabel = store === APPLE ? appleStorePlaeholder : playStorePlaceholder;
+  const storeLink = createTag('a', { href: link,
+  }, getIconElementDeprecated(`${store}-store`));
+  storeLink.setAttribute('aria-label', ariaLabel);
   const { default: trackBranchParameters } = await import('../../scripts/branchlinks.js');
   await trackBranchParameters([storeLink]);
-  return createTag('div', { class: 'ratings-container' }, [score, getIconElementDeprecated('star'), cnt, storeLink]);
+  const star = getIconElementDeprecated('star');
+  star.setAttribute('aria-label', starsPlaceholder);
+  star.setAttribute('role', 'img');
+  return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 
-function makeRatings() {
+async function makeRatings() {
   const ratings = createTag('div', { class: 'ratings' });
   const userAgent = getMobileOperatingSystem();
-  const cb = (el) => el && ratings.append(el);
-  // eslint-disable-next-line chai-friendly/no-unused-expressions
-  userAgent !== 'Android' && makeRating('apple').then(cb);
-  // eslint-disable-next-line chai-friendly/no-unused-expressions
-  userAgent !== 'iOS' && makeRating('google').then(cb);
+  if (userAgent !== 'Android') {
+    const appleElement = await makeRating('apple');
+    appleElement && ratings.append(appleElement);
+  }
+  if (userAgent !== 'iOS') {
+    const googleElement = await makeRating('google');
+    googleElement && ratings.append(googleElement);
+  }
   return ratings;
 }
+
 
 export default async function init(el) {
   ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));

--- a/test/blocks/app-ratings/app-ratings.test.js
+++ b/test/blocks/app-ratings/app-ratings.test.js
@@ -1,0 +1,30 @@
+
+import { readFile } from '@web/test-runner-commands';
+
+const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
+window.isTestEnv = true;
+const imports = await Promise.all([import('../../../express/code/scripts/utils.js'), import('../../../express/code/scripts/scripts.js')]);
+const { getLibs } = imports[0];
+
+await import(`${getLibs()}/utils/utils.js`).then((mod) => {
+  const conf = { locales };
+  mod.setConfig(conf);
+});
+const { default: decorate } = await import('../../../express/code/blocks/app-ratings/app-ratings.js');
+const body = await readFile({ path: './mocks/body.html' });
+document.body.innerHTML = body
+describe('App Ratings', () => {
+  before(() => {
+    window.isTestEnv = true;
+    window.placeholders = {
+      'app-store-ratings': "Test",
+      'app-store-stars': "Test",
+      'app-store-ratings-play-store': "Test",
+      'app-store-ratings-apple-store': "Test",
+    }
+  });
+
+  it('App Ratings exists', async () => {
+    await decorate(document.getElementsByClassName('app-ratings')[0]);
+  })
+})

--- a/test/blocks/app-ratings/app-ratings.test.js
+++ b/test/blocks/app-ratings/app-ratings.test.js
@@ -1,4 +1,3 @@
-
 import { readFile } from '@web/test-runner-commands';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
@@ -12,19 +11,19 @@ await import(`${getLibs()}/utils/utils.js`).then((mod) => {
 });
 const { default: decorate } = await import('../../../express/code/blocks/app-ratings/app-ratings.js');
 const body = await readFile({ path: './mocks/body.html' });
-document.body.innerHTML = body
+document.body.innerHTML = body;
 describe('App Ratings', () => {
   before(() => {
     window.isTestEnv = true;
     window.placeholders = {
-      'app-store-ratings': "Test",
-      'app-store-stars': "Test",
-      'app-store-ratings-play-store': "Test",
-      'app-store-ratings-apple-store': "Test",
-    }
+      'app-store-ratings': 'Test',
+      'app-store-stars': 'Test',
+      'app-store-ratings-play-store': 'Test',
+      'app-store-ratings-apple-store': 'Test',
+    };
   });
 
   it('App Ratings exists', async () => {
     await decorate(document.getElementsByClassName('app-ratings')[0]);
-  })
-})
+  });
+});

--- a/test/blocks/app-ratings/app-ratings.test.js
+++ b/test/blocks/app-ratings/app-ratings.test.js
@@ -1,4 +1,5 @@
 import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
 
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 window.isTestEnv = true;
@@ -24,6 +25,9 @@ describe('App Ratings', () => {
   });
 
   it('App Ratings exists', async () => {
-    await decorate(document.getElementsByClassName('app-ratings')[0]);
+    const block = document.getElementsByClassName('app-ratings')[0];
+    await decorate(block);
+    const googleRating = block.querySelector('.ratings');
+    expect(googleRating).to.exist;
   });
 });

--- a/test/blocks/app-ratings/mocks/body.html
+++ b/test/blocks/app-ratings/mocks/body.html
@@ -1,0 +1,5 @@
+<div class="app-ratings">
+    <div>
+      <div></div>
+    </div>
+  </div>


### PR DESCRIPTION
Describe your specific features or fixes

Moves the app ratings feature of the grid marquee into its own separate block.

Adjusts the CSS of the app ratings slightly

Implements some accessibility + localization for new screen reader labels for app-ratings + grid marquee

Resolves: https://jira.corp.adobe.com/browse/MWPW-170516
https://jira.corp.adobe.com/browse/MWPW-170563
https://jira.corp.adobe.com/browse/MWPW-170565

Test Instructions
 Open /drafts/echen/app-ratings and verify that the widget looks correct on tablet, mobile and desktop. Verify that on mobile apple devices only the apple link shows up and vice versa.
Open the inspector and check the aria labels of the app store links. Make sure they say exactly what is in the image itself. Make sure that the star icon has a role and an aria-label
Verify that there is no regression on the homepage for the grid marquee.

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://separate-grid-marquee-ratings--express-milo--adobecom.aem.page/express/
 https://separate-grid-marquee-ratings--express-milo--adobecom.aem.page/drafts/echen/app-ratings
