### PR TITLE
[MWPW-170829][Prod Bug] Add Commerce Logic to Marquee's Primary CTAs

### DIFF
--- a/express/code/blocks/ax-marquee/ax-marquee.js
+++ b/express/code/blocks/ax-marquee/ax-marquee.js
@@ -464,6 +464,7 @@ async function handleContent(div, block, animations) {
     ];
     if (inlineButtons.length) {
       const primaryCta = inlineButtons[0];
+      formatDynamicCartLink(primaryCta);
       primaryCta.classList.add('button', 'accent', 'primaryCTA', 'xlarge');
       BlockMediator.set('primaryCtaUrl', primaryCta.href);
       primaryCta.parentElement.classList.add(


### PR DESCRIPTION
Adds commerce link dynamic logic to primaryCTAs under all scenarios (inline or content).

Resolves: https://jira.corp.adobe.com/browse/MWPW-170829

How to test:
- The primary "start free trial" CTA in the marquee should have co=za in the branch link, indicating that it's respecting the country=za param. This was not working on the main/stage

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/express/spotlight/marketers?country=za&martech=off
- After: https://marquee-pricing-button-fix--express-milo--adobecom.aem.page/express/spotlight/marketers?country=za&martech=off
