### PR TITLE
[Q2 FY25 | UK LP Hero H1 size change

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1247,6 +1247,10 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   .ax-columns .column-picture{
     width:  unset;
   }
+
+  .section .ax-columns.xl-heading h1 {
+    font-size: var(--heading-font-size-xl);
+  }
 }
 
 .ax-columns.extra-wide {


### PR DESCRIPTION
Describe your specific features or fixes:
* The H1 text size can be authored to 45px

Resolves: [MWPW-170808](https://jira.corp.adobe.com/browse/MWPW-170808)

Authoring Example: 
[uk-campaign-columns-header](https://uk-campaign-columns-header--express-milo--adobecom.aem.page/uk/drafts/jsandlan/uk-campaign-columns-header#)

**Before**:
<img width="820" alt="before" src="https://github.com/user-attachments/assets/7410cff5-b68b-4ee0-b4d7-16a87d2066c8" />

**After**:
<img width="1444" alt="after" src="https://github.com/user-attachments/assets/b634e448-4fc1-404d-a216-a09c7ed687c9" />


Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://www.stage.adobe.com/uk/express/index-2?country=uk
- After: https://uk-campaign-columns-header--express-milo--adobecom.aem.page/uk/drafts/jsandlan/uk-campaign-columns-header#
