### PR TITLE
Allow using Milo columns block on Express pages

### DIFF
--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -493,6 +493,7 @@ function renameConflictingBlocks(area, selector) {
     const columnBlock = section.querySelectorAll('div.columns');
     columnBlock.forEach((column) => {
       if (column.classList[0] !== 'columns') return;
+      if (column.classList.contains('milo')) return;
       column.classList.replace('columns', 'ax-columns');
     });
   };


### PR DESCRIPTION
Make milo variant of columns to be real milo columns.

Resolves: https://jira.corp.adobe.com/browse/MWPW-171155

How to test:
- You should see milo's columns being used on that page, vs. on branch link, you'll see Express's columns being loaded, which doesn't look as nice

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/docs/library/kitchen-sink/?martech=off
- After: https://milo-columns--express-milo--adobecom.aem.page/docs/library/kitchen-sink/?martech=off
