### PR TITLE
[MWPW-171267] Decorate headline without ctas

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -359,6 +359,9 @@ main .section .grid-marquee h1 {
     max-width: 1600px;
     padding-bottom: 40px;
   }
+  .grid-marquee .headline.no-cta {
+    padding-bottom: 0;
+  }
   main .section .grid-marquee .headline h1 {
     font-size: var(--heading-font-size-xl);
   }

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -188,6 +188,7 @@ async function formatDynamicCartLink(a) {
 }
 
 function decorateHeadline(headline) {
+  headline.classList.add('headline');
   const ctas = headline.querySelectorAll('a');
   if (!ctas.length) return headline;
   ctas[0].parentElement.classList.add('ctas');
@@ -196,7 +197,6 @@ function decorateHeadline(headline) {
     formatDynamicCartLink(cta);
   });
   ctas[0].classList.add('primaryCTA');
-  headline.classList.add('headline');
   return headline;
 }
 

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -190,7 +190,10 @@ async function formatDynamicCartLink(a) {
 function decorateHeadline(headline) {
   headline.classList.add('headline');
   const ctas = headline.querySelectorAll('a');
-  if (!ctas.length) return headline;
+  if (!ctas.length) {
+    headline.classList.add('no-cta');
+    return headline;
+  }
   ctas[0].parentElement.classList.add('ctas');
   ctas.forEach((cta) => {
     cta.classList.add('button');


### PR DESCRIPTION
Allow headline to be decorated even when without CTAs.

Resolves: https://jira.corp.adobe.com/browse/MWPW-171267

How to test:
H1 should be bigger on the branch link now.

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/express/fragments/tests/2025/q2/aexg5181v3/business-card?martech=off
- After: https://grid-marquee-h1-no-cta--express-milo--adobecom.aem.page/express/fragments/tests/2025/q2/aexg5181v3/business-card?martech=off
