### PR TITLE
[MWPW-171332] Rm Dependency on old GNAV height

### DIFF
--- a/express/code/blocks/template-list/template-list.css
+++ b/express/code/blocks/template-list/template-list.css
@@ -2286,7 +2286,7 @@
     position: absolute;
     left: 0;
     /* top: 64px; */
-    height: calc(100% - 64px);
+    height: calc(100% - var(--global-height-nav));
     max-height: unset;
     overflow: hidden;
     min-width: unset;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -896,7 +896,8 @@ main.with-holiday-templates-banner {
   background: var(--color-gray-100);
   position: sticky;
   z-index: 1;
-  top: 64px;
+  /* might get overridden by inline style with localnav */
+  top: var(--global-height-nav);
 }
 
 .template-x.print .toolbar-wrapper,
@@ -2725,7 +2726,7 @@ nav ol.templates-breadcrumbs li:not(:first-child):before {
     position: absolute;
     left: 28px;
     top: 120px;
-    height: calc(100% - 64px);
+    height: calc(100% - var(--global-height-nav));
     max-height: unset;
     overflow: hidden;
     min-width: unset;

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1197,6 +1197,9 @@ async function decorateToolbar(block, props) {
   }
 
   block.prepend(tBarWrapper);
+  const { getGnavHeight } = await import(`${getLibs()}/blocks/global-navigation/utilities/utilities.js`);
+  const gnavHeight = getGnavHeight();
+  tBarWrapper.style.top = `${gnavHeight}px`;
   tBarWrapper.append(tBar);
   tBar.append(contentWrapper, functionsWrapper);
   contentWrapper.append(sectionHeading);

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1197,9 +1197,14 @@ async function decorateToolbar(block, props) {
   }
 
   block.prepend(tBarWrapper);
-  const { getGnavHeight } = await import(`${getLibs()}/blocks/global-navigation/utilities/utilities.js`);
-  const gnavHeight = getGnavHeight();
-  tBarWrapper.style.top = `${gnavHeight}px`;
+  try {
+    const { getGnavHeight } = await import(`${getLibs()}/blocks/global-navigation/utilities/utilities.js`);
+    const gnavHeight = getGnavHeight();
+    tBarWrapper.style.top = `${gnavHeight}px`;
+  } catch (e) {
+    window.lana?.log(`Error getting gnav height ${e}`);
+  }
+
   tBarWrapper.append(tBar);
   tBar.append(contentWrapper, functionsWrapper);
   contentWrapper.append(sectionHeading);

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -40,11 +40,6 @@
   --palette-indigo-1000: #4046CA;
   --background-positive-default: #007A4D;
 
-  /* header */
-  --header-height: 65px;
-  --breadcrumbs-height: 43px;
-  --brand-header-height: 79px;
-
   /* body */
   --body-background-color: var(--color-white);
   --body-alt-background-color: var(--color-gray-200);


### PR DESCRIPTION
We have a few places where we hardcoded gnav height, which is changing soon. Update them to either use variables or a dynamic js function.

Resolves: https://jira.corp.adobe.com/browse/MWPW-171332

How to test:
- On mobile template pages, if you scroll down, the gap between the toolbar and localnav should be gone and fixed now.
- There should be no visual changes on anywhere else
- Check on both desktop and mobile for regression across pages


Test URLs:
- Before: https://stage--express-milo--adobecom.aem.live/express/templates/flyer?martech=off
- After: https://gnav-height--express-milo--adobecom.aem.live/express/templates/flyer?martech=off
