### PR TITLE
[Q2 FY25 | UK LP Pricing Card Fix

### DIFF
--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -48,10 +48,6 @@ main .section>.simplified-pricing-cards-wrapper {
 
 }
 
-.simplified-pricing-cards .card:first-of-type {
-    background-color: #F8F8F8;
-}
-
 .simplified-pricing-cards .card.gradient-promo {
     background: linear-gradient(var(--color-white) 0 0) padding-box,
     linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%) border-box;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -49,11 +49,11 @@ main .section>.simplified-pricing-cards-wrapper {
 }
 
 .simplified-pricing-cards.first-card-white .card:first-of-type {
-  background-color: #FFFFFF;
+  background-color: var(--color-white);
 }
 
 .simplified-pricing-cards .card:first-of-type {
-  background-color: #F8F8F8;
+  background-color: var(--color-gray-100);
 }
 
 .simplified-pricing-cards .card.gradient-promo {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -48,6 +48,14 @@ main .section>.simplified-pricing-cards-wrapper {
 
 }
 
+.simplified-pricing-cards.first-card-white .card:first-of-type {
+  background-color: #FFFFFF;
+}
+
+.simplified-pricing-cards .card:first-of-type {
+  background-color: #F8F8F8;
+}
+
 .simplified-pricing-cards .card.gradient-promo {
     background: linear-gradient(var(--color-white) 0 0) padding-box,
     linear-gradient(90deg, #ff477b 0%, #5c5ce0 52%, #318fff 100%) border-box;


### PR DESCRIPTION
Describe your specific features or fixes:
* Remove grey background for free pricing card (1st card) across all break points

Authoring Example: [uk-campaign-columns-header.docx](https://adobe.sharepoint.com/:w:/r/sites/adobecom/Express/website/uk/drafts/jsandlan/uk-campaign-columns-header.docx?d=w37ec8326fb514e2ea8ac45a904e5db51&csf=1&web=1&e=bqDg0T)

Resolves: [MWPW-170811](https://jira.corp.adobe.com/browse/MWPW-170811)

**Authoring Changes**: 
```simplified-pricing-cards (first-card-white) ```

Test URLs:
Before: https://main--express-milo--adobecom.aem.page/uk/drafts/jsandlan/uk-campaign-columns-header?martech=off
After: https://uk-campaign-pricing-cards-outline--express-milo--adobecom.aem.page/uk/drafts/jsandlan/uk-campaign-columns-header?martech=off
