### PR TITLE
Discover Cards Flip [Mobile]: Allow 28px Headline

### DIFF
--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -216,7 +216,6 @@ main .section .discover-cards {
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: 250px;
-  /* justify-content: center; */
 }
 
 .gallery::-webkit-scrollbar {

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -51,8 +51,8 @@ main .section .discover-cards {
 .discover-cards.flip h2 {
   font-size: var(--heading-font-size-s);
 }
-.discover-cards.xl-heading h1,
-.discover-cards.xl-heading h2 {
+.discover-cards.m-heading h1,
+.discover-cards.m-heading h2 {
   font-size: var(--heading-font-size-m);
 }
 /* Default style - centered */

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -62,11 +62,16 @@ main .section .discover-cards {
   scroll-behavior: smooth;
   padding: 3px 16px;
   margin-top: 29px;
-  justify-content: center;
-  width: fit-content;
   max-width: 100vw;
   margin-left: auto;
   margin-right: auto;
+}
+
+@media (min-width: 1300px) {
+  .discover-cards.flip .cards-container.gallery {
+    justify-content: center;
+    width: fit-content;
+  }
 }
 
 /* Switch to left-aligned on smaller screens */
@@ -206,7 +211,7 @@ main .section .discover-cards {
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: 250px;
-  justify-content: center;
+  /* justify-content: center; */
 }
 
 .gallery::-webkit-scrollbar {

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -58,7 +58,7 @@ main .section .discover-cards {
 /* Default style - centered */
 .discover-cards.flip .cards-container.gallery {
   display: grid;
-  grid-auto-flow: column;
+  /* grid-auto-flow: column; */
   grid-auto-columns: 250px;
   gap: 16px;
   overflow-x: scroll;
@@ -83,7 +83,6 @@ main .section .discover-cards {
 @media (max-width: 1050px) {
   .discover-cards.flip .cards-container.gallery {
     justify-content: start;
-    width: 100%;
   }
 }
 
@@ -214,7 +213,7 @@ main .section .discover-cards {
 
 .discover-cards.flip .gallery {
   display: grid;
-  grid-auto-flow: column;
+  grid-auto-flow: column;  
   grid-auto-columns: 250px;
 }
 

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -51,8 +51,8 @@ main .section .discover-cards {
 .discover-cards.flip h2 {
   font-size: var(--heading-font-size-s);
 }
-.discover-cards.m-heading h1,
-.discover-cards.m-heading h2 {
+.discover-cards.xl-heading h1,
+.discover-cards.xl-heading h2 {
   font-size: var(--heading-font-size-m);
 }
 /* Default style - centered */

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -58,7 +58,6 @@ main .section .discover-cards {
 /* Default style - centered */
 .discover-cards.flip .cards-container.gallery {
   display: grid;
-  /* grid-auto-flow: column; */
   grid-auto-columns: 250px;
   gap: 16px;
   overflow-x: scroll;
@@ -213,7 +212,7 @@ main .section .discover-cards {
 
 .discover-cards.flip .gallery {
   display: grid;
-  grid-auto-flow: column;  
+  grid-auto-flow: column;
   grid-auto-columns: 250px;
 }
 

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -13,6 +13,7 @@ main .section .discover-cards {
     background-position: center;
     background-repeat: no-repeat;
 }
+
 .discover-cards .sub-header {
     font-weight: 400;
     font-size: 16px;
@@ -49,6 +50,10 @@ main .section .discover-cards {
 .discover-cards.flip h1, 
 .discover-cards.flip h2 {
   font-size: var(--heading-font-size-s);
+}
+.discover-cards.xl-heading h1,
+.discover-cards.xl-heading h2 {
+  font-size: var(--heading-font-size-m);
 }
 /* Default style - centered */
 .discover-cards.flip .cards-container.gallery {


### PR DESCRIPTION
Describe your specific features or fixes:
* Allow 28px header on mobile
* Ensure there is distance between right side of discover cards flip variant and right side of variant

Authoring Example: [discover-cards-bugs.docx](https://adobe.sharepoint.com/:w:/r/sites/adobecom/Express/website/drafts/jsandlan/discover-cards-bugs.docx?d=w27c713e0d230492dbe00dbb032c4153f&csf=1&web=1&e=fg1s9u)

Resolves: [MWPW-171336](https://jira.corp.adobe.com/browse/MWPW-171336)

Test URLs:
- Before: https://main--express-milo--adobecom.aem.page/drafts/jsandlan/discover-cards-bugs
- After: https://discover-cards-flip-mobile-bugs--express-milo--adobecom.aem.page/drafts/jsandlan/discover-cards-bugs
