### PR TITLE
Authoring Enhancement Columns Block Header Size

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -46,6 +46,24 @@ main .section .ax-columns.enterprise .column h2 {
   max-width: 375px;
 }
 
+.content.columns-m-header h1,
+.content.columns-m-header h2,
+.content.columns-m-header h3,
+.content.columns-m-header h4,
+.content.columns-m-header h5,
+.content.columns-m-header h6 {
+  font-size: var(--heading-font-size-m);
+}
+
+.content.columns-s-header h1,
+.content.columns-s-header h2,
+.content.columns-s-header h3,
+.content.columns-s-header h4,
+.content.columns-s-header h5,
+.content.columns-s-header h6 {
+  font-size: var(--heading-font-size-s);
+}
+
 .section:has(.ax-columns.bg)::before {
   content: '';
   position: absolute;

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -52,7 +52,7 @@ main .section .ax-columns.enterprise .column h2 {
 .content.columns-xl-heading h4,
 .content.columns-xl-heading h5,
 .content.columns-xl-heading h6 {
-  font-size: var(--heading-font-size-m);
+  font-size: var(--heading-font-size-s);
 }
 
 .section:has(.ax-columns.bg)::before {
@@ -1128,8 +1128,8 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   .content.columns-xl-heading h4,
   .content.columns-xl-heading h5,
   .content.columns-xl-heading h6 {
-    font-size: var(--heading-font-size-l);
-}
+    font-size: var(--heading-font-size-m);
+  }
 }
 
 @media (min-width: 1200px) {

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -52,16 +52,16 @@ main .section .ax-columns.enterprise .column h2 {
 .content.columns-m-header h4,
 .content.columns-m-header h5,
 .content.columns-m-header h6 {
-  font-size: var(--heading-font-size-m);
+  font-size: var(--body-font-size-l);
 }
 
-.content.columns-s-header h1,
-.content.columns-s-header h2,
-.content.columns-s-header h3,
-.content.columns-s-header h4,
-.content.columns-s-header h5,
-.content.columns-s-header h6 {
-  font-size: var(--heading-font-size-s);
+.content.columns-xl-header h1,
+.content.columns-xl-header h2,
+.content.columns-xl-header h3,
+.content.columns-xl-header h4,
+.content.columns-xl-header h5,
+.content.columns-xl-header h6 {
+  font-size: var(--body-font-size-xxl);
 }
 
 .section:has(.ax-columns.bg)::before {
@@ -887,6 +887,23 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   .section.long-form:has(.ax-columns:not(.fullsize, .centered)) .content {
     padding: 0 55px 60px;
     max-width: 1100px;
+  }
+  .content.columns-m-header h1,
+  .content.columns-m-header h2,
+  .content.columns-m-header h3,
+  .content.columns-m-header h4,
+  .content.columns-m-header h5,
+  .content.columns-m-header h6 {
+    font-size: var(--heading-font-size-s);
+  }
+
+  .content.columns-xl-header h1,
+  .content.columns-xl-header h2,
+  .content.columns-xl-header h3,
+  .content.columns-xl-header h4,
+  .content.columns-xl-header h5,
+  .content.columns-xl-header h6 {
+    font-size: var(--heading-font-size-m);
   }
 }
 

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -46,22 +46,13 @@ main .section .ax-columns.enterprise .column h2 {
   max-width: 375px;
 }
 
-.content.columns-m-header h1,
-.content.columns-m-header h2,
-.content.columns-m-header h3,
-.content.columns-m-header h4,
-.content.columns-m-header h5,
-.content.columns-m-header h6 {
-  font-size: var(--body-font-size-l);
-}
-
-.content.columns-xl-header h1,
-.content.columns-xl-header h2,
-.content.columns-xl-header h3,
-.content.columns-xl-header h4,
-.content.columns-xl-header h5,
-.content.columns-xl-header h6 {
-  font-size: var(--body-font-size-xxl);
+.content.columns-xl-heading h1,
+.content.columns-xl-heading h2,
+.content.columns-xl-heading h3,
+.content.columns-xl-heading h4,
+.content.columns-xl-heading h5,
+.content.columns-xl-heading h6 {
+  font-size: var(--heading-font-size-m);
 }
 
 .section:has(.ax-columns.bg)::before {
@@ -888,23 +879,6 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
     padding: 0 55px 60px;
     max-width: 1100px;
   }
-  .content.columns-m-header h1,
-  .content.columns-m-header h2,
-  .content.columns-m-header h3,
-  .content.columns-m-header h4,
-  .content.columns-m-header h5,
-  .content.columns-m-header h6 {
-    font-size: var(--heading-font-size-s);
-  }
-
-  .content.columns-xl-header h1,
-  .content.columns-xl-header h2,
-  .content.columns-xl-header h3,
-  .content.columns-xl-header h4,
-  .content.columns-xl-header h5,
-  .content.columns-xl-header h6 {
-    font-size: var(--heading-font-size-m);
-  }
 }
 
 @media (min-width: 900px) and (max-width: 1200px) {
@@ -1147,6 +1121,15 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   main .ax-columns .columns-video {
     min-height: 356px;
   }
+
+  .content.columns-xl-heading h1,
+  .content.columns-xl-heading h2,
+  .content.columns-xl-heading h3,
+  .content.columns-xl-heading h4,
+  .content.columns-xl-heading h5,
+  .content.columns-xl-heading h6 {
+    font-size: var(--heading-font-size-l);
+}
 }
 
 @media (min-width: 1200px) {

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -211,10 +211,6 @@ export default async function decorate(block) {
     }
   }
 
-  if (block.classList.contains('m-heading')) {
-    addHeaderClass(block, 'm');
-  }
-
   if (block.classList.contains('xl-heading')) {
     addHeaderClass(block, 'xl');
   }

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -184,7 +184,7 @@ function addHeaderClass(block, size) {
   if (parentDiv) {
     const parentHeader = parentDiv.querySelector('h1, h2, h3, h4, h5, h6');
     if (parentHeader) {
-      parentHeader.parentElement.classList.add(`columns-${size}-header`);
+      parentHeader.parentElement.classList.add(`columns-${size}-heading`);
     }
   }
 }
@@ -211,11 +211,11 @@ export default async function decorate(block) {
     }
   }
 
-  if (block.classList.contains('m-header')) {
+  if (block.classList.contains('m-heading')) {
     addHeaderClass(block, 'm');
   }
 
-  if (block.classList.contains('xl-header')) {
+  if (block.classList.contains('xl-heading')) {
     addHeaderClass(block, 'xl');
   }
 

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -179,6 +179,16 @@ const decoratePrimaryCTARow = (rowNum, cellNum, cell) => {
   content.parentElement.prepend(links[0]);
 };
 
+function addHeaderClass(block, size) {
+  const parentDiv = block.parentElement;
+  if (parentDiv) {
+    const parentHeader = parentDiv.querySelector('h1, h2, h3, h4, h5, h6');
+    if (parentHeader) {
+      parentHeader.parentElement.classList.add(`columns-${size}-header`);
+    }
+  }
+}
+
 export default async function decorate(block) {
   await Promise.all([import(`${getLibs()}/utils/utils.js`)]).then(([utils]) => {
     ({ createTag, getMetadata, getConfig } = utils);
@@ -199,6 +209,14 @@ export default async function decorate(block) {
     if (columnsWrapper && bgImgURL) {
       columnsWrapper.style.setProperty('--bg-image', `url("${bgImgURL}")`);
     }
+  }
+
+  if (block.classList.contains('s-header')) {
+    addHeaderClass(block, 's');
+  }
+
+  if (block.classList.contains('m-header')) {
+    addHeaderClass(block, 'm');
   }
 
   if (block.classList.contains('narrow')) {

--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -211,12 +211,12 @@ export default async function decorate(block) {
     }
   }
 
-  if (block.classList.contains('s-header')) {
-    addHeaderClass(block, 's');
-  }
-
   if (block.classList.contains('m-header')) {
     addHeaderClass(block, 'm');
+  }
+
+  if (block.classList.contains('xl-header')) {
+    addHeaderClass(block, 'xl');
   }
 
   if (block.classList.contains('narrow')) {


### PR DESCRIPTION
Describe your specific features or fixes:
* Allow authors to set a 28px desktop header and 22px header mobile header for columns

Resolves: [MWPW-159047](https://jira.corp.adobe.com/browse/MWPW-159047)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/drafts/jsandlan/milo-columns-header-enhancement
- After: https://milo-columns-header-enhancement--express-milo--adobecom.aem.page/drafts/jsandlan/milo-columns-header-enhancement
