### PR TITLE
Ensure Surface Specific Table of Contents Appears Without Refresh On Correct Surface

### DIFF
--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -201,18 +201,18 @@ main .section .mobile-toc {
   position: absolute;
   top: -45px;
   left: 0;
-  background: white;
+  background: var(--color-white);
   color: black;
   padding: 8px;
   z-index: 100;
   text-decoration: none;
   transition: top 0.3s ease;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-gray-300);
 }
 
 .skip-link:focus {
   top: 0;
-  outline: 2px solid #0066cc;
+  outline: 2px solid var(--color-blue-600);
   outline-offset: 2px;
 }
 
@@ -221,6 +221,6 @@ main .section .mobile-toc {
 }
 
 .toc-focused {
-  outline: 2px solid #0066cc;
+  outline: 2px solid var(--color-blue-600);
   outline-offset: 2px;
 }

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -197,3 +197,33 @@ main .section .mobile-toc {
     display: none;
   }
 }
+
+/* Skip links for accessibility */
+.skip-link {
+  position: absolute;
+  top: -45px;
+  left: 0;
+  background: white;
+  color: black;
+  padding: 8px;
+  z-index: 100;
+  text-decoration: none;
+  transition: top 0.3s ease;
+  border: 1px solid #ccc;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}
+
+.skip-link.hidden {
+  display: none;
+}
+
+/* Focus styles for TOC */
+.toc-focused {
+  outline: 2px solid #0066cc;
+  outline-offset: 2px;
+}

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -175,8 +175,30 @@ main .section .mobile-toc {
     transform: rotate(135deg);
 }
 
+@media (max-width: 599px) {
+  .table-of-contents-seo {
+    display: none;
+  }
+
+  .mobile-toc {
+    display: block;
+  }
+}
+
 @media (min-width: 600px) {
-    .table-of-contents-seo {
-        display: block;
-    }
+  .table-of-contents-seo {
+    display: block;
+  }
+
+  .mobile-toc {
+    display: none;
+  }
+}
+
+.table-of-contents-seo.mobile-view {
+  display: none !important;
+}
+
+.mobile-toc.desktop-view {
+  display: none !important;
 }

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -131,6 +131,8 @@ main .section .mobile-toc {
     align-items: center;
     cursor: pointer;
     padding: 10px;
+    width: 100%;
+    border: none;
 }
 
 .mobile-toc .toc-content {

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -177,7 +177,6 @@ main .section .mobile-toc {
     transform: rotate(135deg);
 }
 
-/* Put these media queries last in the file to give them highest precedence */
 @media (max-width: 599px) {
   .table-of-contents-seo.mobile-view {
     display: none;
@@ -198,7 +197,6 @@ main .section .mobile-toc {
   }
 }
 
-/* Skip links for accessibility */
 .skip-link {
   position: absolute;
   top: -45px;
@@ -222,7 +220,6 @@ main .section .mobile-toc {
   display: none;
 }
 
-/* Focus styles for TOC */
 .toc-focused {
   outline: 2px solid #0066cc;
   outline-offset: 2px;

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -175,30 +175,23 @@ main .section .mobile-toc {
     transform: rotate(135deg);
 }
 
+/* Put these media queries last in the file to give them highest precedence */
 @media (max-width: 599px) {
-  .table-of-contents-seo {
+  .table-of-contents-seo.mobile-view {
     display: none;
   }
 
-  .mobile-toc {
+  .mobile-toc:not(.desktop-view) {
     display: block;
   }
 }
 
 @media (min-width: 600px) {
-  .table-of-contents-seo {
+  .table-of-contents-seo:not(.mobile-view) {
     display: block;
   }
 
-  .mobile-toc {
+  .mobile-toc.desktop-view {
     display: none;
   }
-}
-
-.table-of-contents-seo.mobile-view {
-  display: none !important;
-}
-
-.mobile-toc.desktop-view {
-  display: none !important;
 }

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.css
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.css
@@ -177,14 +177,12 @@ main .section .mobile-toc {
     transform: rotate(135deg);
 }
 
-@media (max-width: 599px) {
-  .table-of-contents-seo.mobile-view {
-    display: none;
-  }
+.table-of-contents-seo.mobile-view {
+  display: none;
+}
 
-  .mobile-toc:not(.desktop-view) {
-    display: block;
-  }
+.mobile-toc:not(.desktop-view) {
+  display: block;
 }
 
 @media (min-width: 600px) {

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -168,6 +168,7 @@ function handleTOCCloning(toc, tocEntries) {
       'aria-expanded': 'false',
       'aria-controls': 'mobile-toc-content',
       type: 'button',
+      id: 'mobile-toc-button',
     });
 
     const tocTitle = tocClone.querySelector('.toc-title');
@@ -415,7 +416,7 @@ export default async function setTOCSEO() {
   desktopSkipLink.textContent = 'Skip to Table of Contents';
 
   const mobileSkipLink = createTag('a', {
-    href: '#mobile-toc',
+    href: '#mobile-toc-button',
     class: 'skip-link mobile-skip-link',
     'aria-label': 'Skip to Mobile Table of Contents',
   });

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -197,16 +197,28 @@ function handleTOCCloning(toc, tocEntries) {
     tocClone.appendChild(tocContent);
     mainElement.insertAdjacentElement('afterend', tocClone);
 
+    // Add click event listener for the title wrapper
     titleWrapper.addEventListener('click', () => {
       const isExpanded = tocContent.classList.toggle('open');
       tocChevron.classList.toggle('up');
       titleWrapper.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
     });
 
+    // Add keyboard event listener for the title wrapper
     titleWrapper.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         titleWrapper.click();
+      }
+    });
+
+    // Add escape key handler to close the TOC
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && tocContent.classList.contains('open')) {
+        tocContent.classList.remove('open');
+        tocChevron.classList.remove('up');
+        titleWrapper.setAttribute('aria-expanded', 'false');
+        titleWrapper.focus();
       }
     });
 
@@ -330,6 +342,42 @@ function handleSetTOCPos(toc, tocContainer) {
 
 function applyTOCBehavior(toc, tocContainer) {
   handleSetTOCPos(toc, tocContainer);
+
+  const tocContent = toc.querySelector('.toc-content');
+  const tocChevron = toc.querySelector('.toc-chevron');
+  const titleWrapper = toc.querySelector('.toc-title-wrapper');
+
+  if (titleWrapper && tocContent) {
+    // Ensure proper ARIA attributes
+    titleWrapper.setAttribute('aria-expanded', 'false');
+    titleWrapper.setAttribute('aria-controls', 'desktop-toc-content');
+    tocContent.id = 'desktop-toc-content';
+
+    // Add click event listener
+    titleWrapper.addEventListener('click', () => {
+      const isExpanded = tocContent.classList.toggle('open');
+      tocChevron.classList.toggle('up');
+      titleWrapper.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    });
+
+    // Add keyboard event listener
+    titleWrapper.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        titleWrapper.click();
+      }
+    });
+
+    // Add escape key handler
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && tocContent.classList.contains('open')) {
+        tocContent.classList.remove('open');
+        tocChevron.classList.remove('up');
+        titleWrapper.setAttribute('aria-expanded', 'false');
+        titleWrapper.focus();
+      }
+    });
+  }
 }
 
 function initializeTOCContainer() {

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -406,8 +406,35 @@ export default async function setTOCSEO() {
   ({ createTag, getMetadata } = await import(`${getLibs()}/utils/utils.js`));
   const doc = document.querySelector('main');
   const config = buildMetadataConfigObject();
-  const tocSEO = createTag('div', { class: 'table-of-contents-seo' });
-  const toc = createTag('div', { class: 'toc' });
+
+  const desktopSkipLink = createTag('a', {
+    href: '#desktop-toc',
+    class: 'skip-link desktop-skip-link',
+    'aria-label': 'Skip to Table of Contents',
+  });
+  desktopSkipLink.textContent = 'Skip to Table of Contents';
+
+  const mobileSkipLink = createTag('a', {
+    href: '#mobile-toc',
+    class: 'skip-link mobile-skip-link',
+    'aria-label': 'Skip to Mobile Table of Contents',
+  });
+  mobileSkipLink.textContent = 'Skip to Mobile Table of Contents';
+
+  // Add skip links to the document
+  document.body.insertBefore(desktopSkipLink, document.body.firstChild);
+  document.body.insertBefore(mobileSkipLink, document.body.firstChild);
+
+  const tocSEO = createTag('div', {
+    class: 'table-of-contents-seo',
+    id: 'desktop-toc',
+  });
+  const toc = createTag('div', {
+    class: 'toc',
+    tabindex: '0',
+    role: 'navigation',
+    'aria-label': 'Table of Contents',
+  });
   if (config.title) addTOCTitle(toc, config);
 
   // Create both TOCs immediately
@@ -428,12 +455,10 @@ export default async function setTOCSEO() {
 
   let currentMode = null;
 
-  // Handle responsive behavior
   const handleResize = () => {
     const isMobile = window.innerWidth < MOBILE_SIZE;
     const mobileTOC = document.querySelector('.mobile-toc');
 
-    // Only update if the mode has changed
     if (currentMode === isMobile) return;
     currentMode = isMobile;
 
@@ -441,19 +466,30 @@ export default async function setTOCSEO() {
       tocSEO.classList.add('mobile-view');
       if (mobileTOC) {
         mobileTOC.classList.remove('desktop-view');
+        mobileTOC.id = 'mobile-toc';
       }
+      mobileSkipLink.classList.remove('hidden');
+      desktopSkipLink.classList.add('hidden');
     } else {
       tocSEO.classList.remove('mobile-view');
       if (mobileTOC) {
         mobileTOC.classList.add('desktop-view');
       }
       setTOCPosition(toc, tocContainer);
+      desktopSkipLink.classList.remove('hidden');
+      mobileSkipLink.classList.add('hidden');
     }
   };
 
-  // Initial setup
   handleResize();
 
-  // Listen for viewport changes - no debounce needed
   window.addEventListener('resize', handleResize);
+
+  toc.addEventListener('focus', () => {
+    toc.classList.add('toc-focused');
+  });
+
+  toc.addEventListener('blur', () => {
+    toc.classList.remove('toc-focused');
+  });
 }

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -1,21 +1,10 @@
 /* eslint-disable import/named, import/extensions */
 import { getLibs, getIconElementDeprecated } from '../../scripts/utils.js';
-import { debounce } from '../../scripts/utils/hofs.js';
 
 let createTag; let getMetadata;
 
 const MOBILE_SIZE = 600;
 const MOBILE_NAV_HEIGHT = 65;
-const MOBILE = 'MOBILE';
-const DESKTOP = 'DESKTOP';
-const getDeviceType = (() => {
-  let deviceType = window.innerWidth >= MOBILE_SIZE ? DESKTOP : MOBILE;
-  const updateDeviceType = () => {
-    deviceType = window.innerWidth >= MOBILE_SIZE ? DESKTOP : MOBILE;
-  };
-  window.addEventListener('resize', debounce(updateDeviceType, 100));
-  return () => deviceType;
-})();
 
 function setBoldStyle(element) {
   const tocNumber = element.querySelector('.toc-number');
@@ -105,18 +94,16 @@ function addTOCItemClickEvent(tocItem, heading) {
       const offsetPosition = headerRect.top + window.scrollY - headerOffset - MOBILE_NAV_HEIGHT;
       window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
     } else {
-      console.error(`Element with id "${targetHeading.id}" not found.`);
+      window.lana.log(`Element with id "${targetHeading.id}" not found.`);
     }
     document.querySelector('.toc-content')?.classList.toggle('open');
   }
 
-  // Add click event
   tocItem.addEventListener('click', (event) => {
     event.preventDefault();
     scrollToHeading(heading);
   });
 
-  // Add keyboard support
   tocItem.addEventListener('keydown', (event) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
@@ -124,7 +111,6 @@ function addTOCItemClickEvent(tocItem, heading) {
     }
   });
 
-  // Add focus events for visual indicator
   tocItem.addEventListener('focus', () => {
     tocItem.classList.add('toc-focus');
   });
@@ -133,7 +119,6 @@ function addTOCItemClickEvent(tocItem, heading) {
     tocItem.classList.remove('toc-focus');
   });
 
-  // Make the element focusable
   tocItem.setAttribute('tabindex', '0');
 }
 

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -231,7 +231,6 @@ function addTOCEntries(toc, config, doc) {
     }
   });
 
-  if (getDeviceType() !== DESKTOP) handleTOCCloning(toc, tocEntries);
   return tocEntries;
 }
 
@@ -359,7 +358,7 @@ export default async function setTOCSEO() {
   const tocEntries = addTOCEntries(toc, config, doc);
   addHoverEffect(tocEntries);
 
-  // Create mobile TOC immediately
+  // Create mobile TOC
   handleTOCCloning(toc, tocEntries);
 
   // Set up desktop behaviors

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -134,19 +134,25 @@ function handleTOCCloning(toc, tocEntries) {
   if (mainElement) {
     const tocClone = toc.cloneNode(true);
     tocClone.classList.add('mobile-toc');
+    tocClone.setAttribute('role', 'navigation');
+    tocClone.setAttribute('aria-label', 'Table of Contents');
 
     const titleWrapper = createTag('button', {
       class: 'toc-title-wrapper',
-      'aria-expanded': 'false', // Initial state is collapsed
-      'aria-controls': 'mobile-toc-content', // Links button to content it controls
-      type: 'button', // Explicit button type
+      'aria-expanded': 'false',
+      'aria-controls': 'mobile-toc-content',
+      type: 'button',
     });
 
     const tocTitle = tocClone.querySelector('.toc-title');
+    if (tocTitle) {
+      tocTitle.setAttribute('role', 'heading');
+      tocTitle.setAttribute('aria-level', '2');
+    }
 
     const tocChevron = document.createElement('span');
     tocChevron.className = 'toc-chevron';
-    tocChevron.setAttribute('aria-hidden', 'true'); // Hide icon from screen readers
+    tocChevron.setAttribute('aria-hidden', 'true');
 
     titleWrapper.appendChild(tocTitle);
     titleWrapper.appendChild(tocChevron);
@@ -156,6 +162,20 @@ function handleTOCCloning(toc, tocEntries) {
     const tocContent = createTag('ul', {
       class: 'toc-content',
       id: 'mobile-toc-content',
+      'aria-label': 'Table of Contents Sections',
+    });
+
+    const entries = tocClone.querySelectorAll('.toc-entry');
+    entries.forEach((entry) => {
+      const li = document.createElement('li');
+
+      Array.from(entry.attributes).forEach((attr) => {
+        li.setAttribute(attr.name, attr.value);
+      });
+
+      li.innerHTML = entry.innerHTML;
+
+      entry.parentNode.replaceChild(li, entry);
     });
 
     tocClone.querySelectorAll('.toc-entry').forEach((entry) => {

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -404,6 +404,6 @@ export default async function setTOCSEO() {
   // Initial setup
   handleResize();
 
-  // Listen for viewport changes
-  window.addEventListener('resize', debounce(handleResize, 100));
+  // Listen for viewport changes - no debounce needed
+  window.addEventListener('resize', handleResize);
 }

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -171,9 +171,6 @@ function handleTOCCloning(toc, tocEntries) {
     const sticky = tocClone.offsetTop - MOBILE_NAV_HEIGHT;
     window.addEventListener('scroll', () => toggleSticky(tocClone, sticky));
   }
-
-  const originalTOC = document.querySelector('.table-of-contents-seo');
-  if (originalTOC) originalTOC.style.display = 'none';
 }
 
 function setupTOCItem(tocItem, tocCounter, headingText, headingId) {
@@ -261,7 +258,6 @@ function setTOCPosition(toc, tocContainer) {
     : `${targetTop}px`;
 
   tocContainer.style.position = targetTop <= window.scrollY + viewportMidpoint ? 'fixed' : 'absolute';
-  tocContainer.style.display = 'block';
 
   const footer = document.querySelector('footer');
 
@@ -287,15 +283,11 @@ function handleSetTOCPos(toc, tocContainer) {
 }
 
 function applyTOCBehavior(toc, tocContainer) {
-  document.querySelectorAll('.mobile-toc').forEach((mobileToc) => {
-    mobileToc.style.display = 'none';
-  });
   handleSetTOCPos(toc, tocContainer);
 }
 
 function initializeTOCContainer() {
   const tocContainer = document.querySelector('.table-of-contents-seo');
-  tocContainer.style.display = 'none';
   return tocContainer;
 }
 
@@ -389,13 +381,11 @@ export default async function setTOCSEO() {
       tocSEO.classList.add('mobile-view');
       if (mobileTOC) {
         mobileTOC.classList.remove('desktop-view');
-        mobileTOC.style.display = 'block';
       }
     } else {
       tocSEO.classList.remove('mobile-view');
       if (mobileTOC) {
         mobileTOC.classList.add('desktop-view');
-        mobileTOC.style.display = 'none';
       }
       setTOCPosition(toc, tocContainer);
     }

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -96,19 +96,45 @@ function assignHeadingIdIfNeeded(heading, headingText) {
 }
 
 function addTOCItemClickEvent(tocItem, heading) {
-  tocItem.addEventListener('click', (event) => {
-    event.preventDefault();
-    const headerElement = document.getElementById(heading.id);
+  // Helper function to scroll to heading
+  function scrollToHeading(targetHeading) {
+    const headerElement = document.getElementById(targetHeading.id);
     if (headerElement) {
       const headerRect = headerElement.getBoundingClientRect();
       const headerOffset = 70;
       const offsetPosition = headerRect.top + window.scrollY - headerOffset - MOBILE_NAV_HEIGHT;
       window.scrollTo({ top: offsetPosition, behavior: 'smooth' });
     } else {
-      console.error(`Element with id "${heading.id}" not found.`);
+      console.error(`Element with id "${targetHeading.id}" not found.`);
     }
     document.querySelector('.toc-content')?.classList.toggle('open');
+  }
+
+  // Add click event
+  tocItem.addEventListener('click', (event) => {
+    event.preventDefault();
+    scrollToHeading(heading);
   });
+
+  // Add keyboard support
+  tocItem.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      scrollToHeading(heading);
+    }
+  });
+
+  // Add focus events for visual indicator
+  tocItem.addEventListener('focus', () => {
+    tocItem.classList.add('toc-focus');
+  });
+
+  tocItem.addEventListener('blur', () => {
+    tocItem.classList.remove('toc-focus');
+  });
+
+  // Make the element focusable
+  tocItem.setAttribute('tabindex', '0');
 }
 
 function findCorrespondingHeading(headingText, doc) {

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -4,7 +4,7 @@ import { getLibs, getIconElementDeprecated } from '../../scripts/utils.js';
 let createTag; let getMetadata;
 
 const MOBILE_SIZE = 600;
-const MOBILE_NAV_HEIGHT = 65;
+let MOBILE_NAV_HEIGHT;
 
 function setBoldStyle(element) {
   const tocNumber = element.querySelector('.toc-number');
@@ -435,6 +435,13 @@ export default async function setTOCSEO() {
   ({ createTag, getMetadata } = await import(`${getLibs()}/utils/utils.js`));
   const doc = document.querySelector('main');
   const config = buildMetadataConfigObject();
+
+  try {
+    const { getGnavHeight } = await import(`${getLibs()}/blocks/global-navigation/utilities/utilities.js`);
+    MOBILE_NAV_HEIGHT = getGnavHeight();
+  } catch (e) {
+    window.lana?.log(`Error getting gnav height ${e}`);
+  }
 
   const desktopSkipLink = createTag('a', {
     href: '#desktop-toc',

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -235,7 +235,7 @@ function handleTOCCloning(toc, tocEntries) {
 function setupTOCItem(tocItem, tocCounter, headingText, headingId) {
   tocItem.innerHTML = `
     <span class="toc-number">${tocCounter}</span>
-    <a href="#${headingId}" daa-ll="${headingText}-${tocCounter}--">
+    <a href="#${headingId}" daa-ll="${headingText}-${tocCounter}--table-of-contents">
       ${headingText}
     </a>
   `;

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -85,7 +85,6 @@ function assignHeadingIdIfNeeded(heading, headingText) {
 }
 
 function addTOCItemClickEvent(tocItem, heading) {
-  // Helper function to scroll to heading
   function scrollToHeading(targetHeading) {
     const headerElement = document.getElementById(targetHeading.id);
     if (headerElement) {
@@ -348,19 +347,16 @@ function applyTOCBehavior(toc, tocContainer) {
   const titleWrapper = toc.querySelector('.toc-title-wrapper');
 
   if (titleWrapper && tocContent) {
-    // Ensure proper ARIA attributes
     titleWrapper.setAttribute('aria-expanded', 'false');
     titleWrapper.setAttribute('aria-controls', 'desktop-toc-content');
     tocContent.id = 'desktop-toc-content';
 
-    // Add click event listener
     titleWrapper.addEventListener('click', () => {
       const isExpanded = tocContent.classList.toggle('open');
       tocChevron.classList.toggle('up');
       titleWrapper.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
     });
 
-    // Add keyboard event listener
     titleWrapper.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
@@ -368,7 +364,6 @@ function applyTOCBehavior(toc, tocContainer) {
       }
     });
 
-    // Add escape key handler
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && tocContent.classList.contains('open')) {
         tocContent.classList.remove('open');
@@ -471,19 +466,15 @@ export default async function setTOCSEO() {
   });
   if (config.title) addTOCTitle(toc, config);
 
-  // Create both TOCs immediately
   tocSEO.appendChild(toc);
   doc.appendChild(tocSEO);
   const tocContainer = initializeTOCContainer();
 
-  // Create TOC entries for desktop version
   const tocEntries = addTOCEntries(toc, config, doc);
   addHoverEffect(tocEntries);
 
-  // Create mobile TOC
   handleTOCCloning(toc, tocEntries);
 
-  // Set up desktop behaviors
   applyTOCBehavior(toc, tocContainer);
   handleActiveTOCHighlighting(tocEntries);
 

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -135,13 +135,18 @@ function handleTOCCloning(toc, tocEntries) {
     const tocClone = toc.cloneNode(true);
     tocClone.classList.add('mobile-toc');
 
-    const titleWrapper = document.createElement('div');
-    titleWrapper.classList.add('toc-title-wrapper');
+    const titleWrapper = createTag('button', {
+      class: 'toc-title-wrapper',
+      'aria-expanded': 'false', // Initial state is collapsed
+      'aria-controls': 'mobile-toc-content', // Links button to content it controls
+      type: 'button', // Explicit button type
+    });
 
     const tocTitle = tocClone.querySelector('.toc-title');
 
     const tocChevron = document.createElement('span');
     tocChevron.className = 'toc-chevron';
+    tocChevron.setAttribute('aria-hidden', 'true'); // Hide icon from screen readers
 
     titleWrapper.appendChild(tocTitle);
     titleWrapper.appendChild(tocChevron);
@@ -150,6 +155,7 @@ function handleTOCCloning(toc, tocEntries) {
 
     const tocContent = document.createElement('div');
     tocContent.className = 'toc-content';
+    tocContent.id = 'mobile-toc-content'; // ID to match aria-controls
 
     tocClone.querySelectorAll('.toc-entry').forEach((entry) => {
       tocContent.appendChild(entry);
@@ -159,8 +165,16 @@ function handleTOCCloning(toc, tocEntries) {
     mainElement.insertAdjacentElement('afterend', tocClone);
 
     titleWrapper.addEventListener('click', () => {
-      tocContent.classList.toggle('open');
+      const isExpanded = tocContent.classList.toggle('open');
       tocChevron.classList.toggle('up');
+      titleWrapper.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+    });
+
+    titleWrapper.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        titleWrapper.click();
+      }
     });
 
     const clonedTOCEntries = tocContent.querySelectorAll('.toc-entry');

--- a/express/code/features/table-of-contents-seo/table-of-contents-seo.js
+++ b/express/code/features/table-of-contents-seo/table-of-contents-seo.js
@@ -153,9 +153,10 @@ function handleTOCCloning(toc, tocEntries) {
 
     tocClone.insertBefore(titleWrapper, tocClone.firstChild);
 
-    const tocContent = document.createElement('div');
-    tocContent.className = 'toc-content';
-    tocContent.id = 'mobile-toc-content'; // ID to match aria-controls
+    const tocContent = createTag('ul', {
+      class: 'toc-content',
+      id: 'mobile-toc-content',
+    });
 
     tocClone.querySelectorAll('.toc-entry').forEach((entry) => {
       tocContent.appendChild(entry);

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -18,6 +18,7 @@
   --color-gray-600: #686868;
   --color-gray-700: #444;
   --color-gray-800: #242424;
+  --color-blue-600: #0066CC;
   --color-black: #000;
   --color-brand-title: #000b1d;
   --color-info-accent: #5c5ce0;


### PR DESCRIPTION
Describe your specific features or fixes:
* Ensure TOC dynamically appears as mobile TOC on mobile or desktop TOC on desktop as viewport resizes without refresh
* adds a11y fixes including skip links for mobile and desktop toc, use of semantic HTML for toc structure, aria-relevant data

Resolves: [MWPW-170230](https://jira.corp.adobe.com/browse/MWPW-170230)

**This is a sticky nav so will load below the marquee on initial load and then become sticky as the user scrolls down the page.**

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://toc-mobile-desktop--express-milo--adobecom.aem.page/drafts/jsandlan/milo-toc-content-numbers
