### PR TITLE
[MWPW-162405] Remove assigning to innerhtml

### DIFF
--- a/express/code/scripts/utils/template-ckg.js
+++ b/express/code/scripts/utils/template-ckg.js
@@ -58,8 +58,10 @@ function replaceLinkPill(linkPill, data) {
   if (data) {
     const sanitizedUrl = sanitizeHTML(data.url);
     const sanitizedShortTitle = sanitizeHTML(data['short-title']);
-    clone.innerHTML = clone.innerHTML.replace('/express/templates/default', sanitizedUrl);
-    clone.innerHTML = clone.innerHTML.replaceAll('Default', sanitizedShortTitle);
+    const a = clone.querySelector('a');
+    a.textContent = a.textContent.replaceAll('Default', sanitizedShortTitle);
+    a.title = a.textContent.replaceAll('Default', sanitizedShortTitle);
+    a.href = a.href.replace('/express/templates/default', sanitizedUrl);
   }
   if (data?.url && isSearch(data.url)) {
     clone.querySelectorAll('a').forEach((a) => {
@@ -144,10 +146,10 @@ async function updateLinkList(container, linkPill, list) {
       };
 
       clone = replaceLinkPill(linkPill, pageData);
-      clone.innerHTML = clone.innerHTML
-        .replaceAll('Default', sanitizeHTML(d.displayValue))
-        .replace('/express/templates/default', sanitizeHTML(d.pathname));
       const innerLink = clone.querySelector('a');
+      innerLink.textContent = innerLink.textContent.replaceAll('Default', sanitizeHTML(d.displayValue));
+      innerLink.title = innerLink.textContent.replaceAll('Default', sanitizeHTML(d.displayValue));
+      innerLink.href = innerLink.href.replace('/express/templates/default', sanitizeHTML(d.pathname));
       if (innerLink) {
         const url = new URL(innerLink.href, window.location.href);
         if (!url.searchParams.get('searchId')) {


### PR DESCRIPTION
Retire assigning of innerhtml for template-ckg.js.

Resolves: https://jira.corp.adobe.com/browse/MWPW-162405

How to test:
1. Due to ckg api does not work on branch links, the easiest way of testing is to use source override in Chrome
2. Copy the whole script file at https://github.com/adobecom/express-milo/blob/template-ckg-inner/express/code/scripts/utils/template-ckg.js, the only file modified in this PR
3. Go to www.adobe.com/express/templates/flyer and open up Dev tools, Sources tab
4. Under Overrides, check Enable Local Overrides
5. Under Page, find www.adobe.com/express/code/scripts/utils/template-ckg.js
6. Paste and override the whole file
7. Save and Refresh
8. You should see the CKG pills in search-marquee continues to work as before
9. **Once on stage, we can use www.stage.adobe.com/express/templates/flyer to verify without needing to use overrides. So we can also let this get to stage and test there**

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.live/express/templates/flyer?martech=off
- After: https://template-ckg-inner--express-milo--adobecom.aem.live/express/templates/flyer?martech=off
