### PR TITLE
[MWPW-172159] New Commerce Segmentation Links

### DIFF
--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -236,8 +236,8 @@ export async function fetchPlanOnePlans(planUrl) {
     }
 
     const offer = await getOfferOnePlans(plan.offerId);
-
-    if (offer) {
+    const foundOffer = Object.keys(offer).length > 0;
+    if (foundOffer) {
       plan.currency = offer.currency;
       plan.price = offer.unitPrice;
       plan.basePrice = offer.basePrice;
@@ -266,6 +266,10 @@ export async function fetchPlanOnePlans(planUrl) {
         );
       }
       plan.y2p = offer.y2p;
+    } else {
+      const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
+      plan.country = await getCountry();
+      [plan.lang] = getConfig().locale.ietf.split('-');
     }
     window.pricingPlans[planUrl] = plan;
   }

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -267,7 +267,7 @@ export async function fetchPlanOnePlans(planUrl) {
       }
       plan.y2p = offer.y2p;
     } else {
-      const [country, { getConfig }] = await Promise.all([getCountry, import(`${getLibs()}/utils/utils.js`)]);
+      const [country, { getConfig }] = await Promise.all([getCountry(), import(`${getLibs()}/utils/utils.js`)]);
       plan.country = country;
       [plan.lang] = getConfig().locale.ietf.split('-');
     }

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -267,8 +267,8 @@ export async function fetchPlanOnePlans(planUrl) {
       }
       plan.y2p = offer.y2p;
     } else {
-      const { getConfig } = await import(`${getLibs()}/utils/utils.js`);
-      plan.country = await getCountry();
+      const [country, getConfig] = await Promise.all([getCountry, import(`${getLibs()}/utils/utils.js`)]);
+      plan.country = country;
       [plan.lang] = getConfig().locale.ietf.split('-');
     }
     window.pricingPlans[planUrl] = plan;

--- a/express/code/scripts/utils/pricing.js
+++ b/express/code/scripts/utils/pricing.js
@@ -267,7 +267,7 @@ export async function fetchPlanOnePlans(planUrl) {
       }
       plan.y2p = offer.y2p;
     } else {
-      const [country, getConfig] = await Promise.all([getCountry, import(`${getLibs()}/utils/utils.js`)]);
+      const [country, { getConfig }] = await Promise.all([getCountry, import(`${getLibs()}/utils/utils.js`)]);
       plan.country = country;
       [plan.lang] = getConfig().locale.ietf.split('-');
     }

--- a/test/scripts/pricing.test.js
+++ b/test/scripts/pricing.test.js
@@ -1,0 +1,90 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import { mockRes } from '../blocks/test-utilities.js';
+import { fetchPlanOnePlans } from '../../express/code/scripts/utils/pricing.js';
+
+const imports = await Promise.all([import('../../express/code/scripts/utils.js'), import('../../express/code/scripts/scripts.js')]);
+const [{ getLibs }] = imports;
+
+const originalFetch = window.fetch;
+
+describe('Pricing offer format for segmentation link', () => {
+  afterEach(() => {
+    window.fetch = originalFetch;
+    sessionStorage.removeItem('visitorCountry');
+  });
+  it('handles US IP', async () => {
+    await import(`${getLibs()}/utils/utils.js`).then((mod) => {
+      const conf = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+      mod.setConfig(conf);
+    });
+    window.fetch = sinon.stub();
+    window.fetch.onFirstCall().returns(mockRes({
+      payload: {
+        country: 'US',
+        state: 'CA',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    }));
+    window.fetch.onSecondCall().returns(mockRes({
+      payload: {
+        data: {
+          find: () => {},
+        },
+      },
+    }));
+    const res = await fetchPlanOnePlans('https://commerce-stg.adobe.com/store/segmentation?cli=cc_express&pa=PA-55&ot=trial&us');
+    expect(res.country).to.equal('us');
+    expect(res.language).to.equal('en');
+  });
+
+  it('handles Bangalore IP', async () => {
+    await import(`${getLibs()}/utils/utils.js`).then((mod) => {
+      const conf = { locales: { '': { ietf: 'en-US', tk: 'hah7vzn.css' } } };
+      mod.setConfig(conf);
+    });
+    window.fetch = sinon.stub();
+    window.fetch.onFirstCall().returns(mockRes({
+      payload: {
+        country: 'in',
+        state: 'up',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    }));
+    window.fetch.onSecondCall().returns(mockRes({
+      payload: {
+        data: {
+          find: () => {},
+        },
+      },
+    }));
+    const res = await fetchPlanOnePlans('https://commerce-stg.adobe.com/store/segmentation?cli=cc_express&pa=PA-55&ot=trial&in');
+    expect(res.country).to.equal('in');
+    expect(res.language).to.equal('en');
+  });
+
+  it('handles Tokyo IP', async () => {
+    await import(`${getLibs()}/utils/utils.js`).then((mod) => {
+      const conf = { locales: { '': { ietf: 'ja-JP', tk: 'hah7vzn.css' } } };
+      mod.setConfig(conf);
+    });
+    window.fetch = sinon.stub();
+    window.fetch.onFirstCall().returns(mockRes({
+      payload: {
+        country: 'jp',
+        state: '13',
+        'Accept-Language': 'en-US,en;q=0.9',
+      },
+    }));
+    window.fetch.onSecondCall().returns(mockRes({
+      payload: {
+        data: {
+          find: () => {},
+        },
+      },
+    }));
+    const res = await fetchPlanOnePlans('https://commerce-stg.adobe.com/store/segmentation?cli=cc_express&pa=PA-55&ot=trial&jp');
+    expect(res.country).to.equal('jp');
+    expect(res.lang).to.equal('ja');
+  });
+});

--- a/test/scripts/pricing.test.js
+++ b/test/scripts/pricing.test.js
@@ -46,8 +46,8 @@ describe('Pricing offer format for segmentation link', () => {
     window.fetch = sinon.stub();
     window.fetch.onFirstCall().returns(mockRes({
       payload: {
-        country: 'in',
-        state: 'up',
+        country: 'IN',
+        state: 'UP',
         'Accept-Language': 'en-US,en;q=0.9',
       },
     }));
@@ -71,7 +71,7 @@ describe('Pricing offer format for segmentation link', () => {
     window.fetch = sinon.stub();
     window.fetch.onFirstCall().returns(mockRes({
       payload: {
-        country: 'jp',
+        country: 'JP',
         state: '13',
         'Accept-Language': 'en-US,en;q=0.9',
       },


### PR DESCRIPTION
Support new segmentation commerce links to have co and lang params.

Resolves: https://jira.corp.adobe.com/browse/MWPW-172159

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/drafts/jingle/pricing?martech=off
- After: https://commerce-segmentation--express-milo--adobecom.aem.page/drafts/jingle/pricing?martech=off

How to test:
- Go to the branch link and check the CTA in the Premium card
- It should have co and lang params
- On stage, co and lang would be undefined

Links to test for regression:
- All the pricing cards on pricing page and simplified-pricing-cards on homepage should not be affected at all, as this PR is a new feature for new authoring links.
- https://commerce-segmentation--express-milo--adobecom.aem.live/express/pricing?martech=off
- https://commerce-segmentation--express-milo--adobecom.aem.live/express/?martech=off
