### PR TITLE
[MWPW-171648] Tooltip Homepage Fix

### DIFF
--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -344,7 +344,7 @@ function handleTooltip(pricingArea) {
   const icon = getIconElementDeprecated('info', 44, 'Info', 'tooltip-icon');
   icon.append(span);
   const iconWrapper = createTag('button');
-  icon.setAttribute('tabindex', 1);
+  icon.setAttribute('tabindex', 0);
   iconWrapper.setAttribute('aria-label', tooltipText);
   iconWrapper.append(icon);
   iconWrapper.append(span);

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -52,7 +52,7 @@ export function handleTooltip(pricingArea) {
   icon.append(span);
   const iconWrapper = createTag('button');
   iconWrapper.setAttribute('aria-label', tooltipText);
-  icon.setAttribute('tabindex', 1);
+  icon.setAttribute('tabindex', 0);
   iconWrapper.append(icon);
   iconWrapper.append(span);
   tooltipDiv.append(iconWrapper);


### PR DESCRIPTION
Describe your specific features or fixes

Sets tabindex to 0 for the simplified pricing card tooltip

Resolves:  https://jira.corp.adobe.com/browse/MWPW-171648

Test Instructions:
Navigate to the homepage and tab at the top of the page. The page should not jump to the pricing cards but act normally.
Navigate to the pricing card section and mouse over the area. Ensure that it behaves the same as before. 

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://simplified-pricing-card-tab-index--express-milo--adobecom.aem.page/express/
