### PR TITLE
[MWPW-172485] More Specific Showwith section-metadata for Frictionless Audience

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -68,6 +68,10 @@
     height: 100%;
 }
 
+.frictionless-quick-action-mobile .animation-container img {
+  width: 100%;
+}
+
 .frictionless-quick-action-mobile .animation-container.hide {
     display: none;
 }

--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -348,19 +348,20 @@ export default async function decorate(block) {
   };
 
   const dropzone = createTag('button', { class: 'dropzone hide', id: 'mobile-fqa-upload' });
-  const [animationContainer, dropzoneContent] = rows[1].children;
+  const [animationContainer, dropzoneContent] = dropzoneContainer.children;
   while (dropzoneContent.firstChild) dropzone.append(dropzoneContent.firstChild);
   dropzoneContent.replaceWith(dropzone);
   animationContainer.classList.add('animation-container');
   const animation = animationContainer.querySelector('a');
-
+  const animationEnd = () => {
+    dropzone.classList.remove('hide');
+    animationContainer.classList.add('hide');
+  };
   if (animation && animation.href.includes('.mp4')) {
     const video = transformLinkToAnimation(animation, false);
-    video.addEventListener('ended', () => {
-      dropzone.classList.remove('hide');
-      animationContainer.classList.add('hide');
-    });
-    // click to skip animation
+    video.addEventListener('ended', animationEnd);
+  } else if (animationContainer.querySelector('picture')) {
+    setTimeout(animationEnd, 3000);
   }
   const dropzoneText = createTag('div', { class: 'text' });
   while (dropzone.firstChild) {

--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -297,6 +297,7 @@ export default async function decorate(block) {
   const rows = Array.from(block.children);
   const [quickActionRow] = rows.filter((row) => row.children[0]?.textContent?.toLowerCase()?.trim() === 'quick-action');
   quickActionRow?.remove();
+  // TODO: remove fallback row once authoring is done
   const [fallbackRow] = rows.filter((row) => row.children[0]?.textContent?.toLowerCase()?.trim() === 'fallback');
   fallbackRow?.remove();
   if (fallbackRow && getMobileOperatingSystem() !== 'Android') {

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -411,20 +411,22 @@ function hideQuickActionsOnDevices() {
   const fqaMeta = document.createElement('meta');
   fqaMeta.setAttribute('content', 'on');
   const isMobile = document.body.dataset.device === 'mobile';
+  // safari won't work either mobile or desktop
   const isQualifiedBrowser = !/Safari/.test(userAgent) || /Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent);
-  if (!isQualifiedBrowser) {
-    fqaMeta.setAttribute('name', 'fqa-off');
+  if (isMobile || !isQualifiedBrowser) {
+    fqaMeta.setAttribute('name', 'fqa-off'); // legacy setup for mobile or desktop_safari
   } else {
-    if (!isMobile) {
-      // legacy setup for desktop + non_safari == desktop-fqa-qualified
-      fqaMeta.setAttribute('name', 'fqa-on');
-    }
-    const audienceFqaMeta = document.createElement('meta');
-    audienceFqaMeta.setAttribute('content', 'on');
-    audienceFqaMeta.setAttribute('name', isMobile ? 'mobile-fqa-qualified' : 'desktop-fqa-qualified');
-    document.head.append(audienceFqaMeta);
+    fqaMeta.setAttribute('name', 'fqa-on'); // legacy setup for desktop or non_safari
   }
-  document.head.append(fqaMeta);
+  // up-to-date setup that supports mobile frictionless
+  const audienceFqaMeta = document.createElement('meta');
+  audienceFqaMeta.setAttribute('content', 'on');
+  if (isQualifiedBrowser) {
+    audienceFqaMeta.setAttribute('name', isMobile ? 'mobile-fqa-qualified' : 'desktop-fqa-qualified');
+  } else {
+    audienceFqaMeta.setAttribute('name', 'fqa-non-qualified');
+  }
+  document.head.append(fqaMeta, audienceFqaMeta);
 }
 
 export function preDecorateSections(area) {
@@ -448,7 +450,7 @@ export function preDecorateSections(area) {
             || urlParams.get(`${sectionMeta.showwith}`);
         }
         const showwith = sectionMeta.showwith.toLowerCase();
-        if (['fqa-off', 'fqa-on', 'mobile-fqa-qualified', 'desktop-fqa-qualified'].includes(showwith)) hideQuickActionsOnDevices();
+        if (['fqa-off', 'fqa-on', 'fqa-non-qualified', 'mobile-fqa-qualified', 'desktop-fqa-qualified'].includes(showwith)) hideQuickActionsOnDevices();
         sectionRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(showwith) !== 'on';
       }
       if (sectionRemove) section.remove();

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -412,10 +412,13 @@ function hideQuickActionsOnDevices() {
   fqaMeta.setAttribute('content', 'on');
   const isMobile = document.body.dataset.device === 'mobile';
   const isQualifiedBrowser = !/Safari/.test(userAgent) || /Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent);
-  if (isMobile || !isQualifiedBrowser) {
+  if (!isQualifiedBrowser) {
     fqaMeta.setAttribute('name', 'fqa-off');
   } else {
-    fqaMeta.setAttribute('name', 'fqa-on');
+    if (!isMobile) {
+      // legacy setup for desktop + non_safari
+      fqaMeta.setAttribute('name', 'fqa-on');
+    }
     const audienceFqaMeta = document.createElement('meta');
     audienceFqaMeta.setAttribute('content', 'on');
     audienceFqaMeta.setAttribute('name', isMobile ? 'mobile-fqa-qualified' : 'desktop-fqa-qualified');

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -422,7 +422,7 @@ function hideQuickActionsOnDevices() {
   const audienceFqaMeta = document.createElement('meta');
   audienceFqaMeta.setAttribute('content', 'on');
   if (isQualifiedBrowser) {
-    audienceFqaMeta.setAttribute('name', isMobile ? 'mobile-fqa-qualified' : 'desktop-fqa-qualified');
+    audienceFqaMeta.setAttribute('name', `fqa-qualified-${isMobile ? 'mobile' : 'desktop'}`);
   } else {
     audienceFqaMeta.setAttribute('name', 'fqa-non-qualified');
   }
@@ -450,7 +450,7 @@ export function preDecorateSections(area) {
             || urlParams.get(`${sectionMeta.showwith}`);
         }
         const showwith = sectionMeta.showwith.toLowerCase();
-        if (['fqa-off', 'fqa-on', 'fqa-non-qualified', 'mobile-fqa-qualified', 'desktop-fqa-qualified'].includes(showwith)) hideQuickActionsOnDevices();
+        if (['fqa-off', 'fqa-on', 'fqa-non-qualified', 'fqa-qualified-mobile', 'fqa-qualified-desktop'].includes(showwith)) hideQuickActionsOnDevices();
         sectionRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(showwith) !== 'on';
       }
       if (sectionRemove) section.remove();

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -416,7 +416,7 @@ function hideQuickActionsOnDevices() {
     fqaMeta.setAttribute('name', 'fqa-off');
   } else {
     if (!isMobile) {
-      // legacy setup for desktop + non_safari
+      // legacy setup for desktop + non_safari == desktop-fqa-qualified
       fqaMeta.setAttribute('name', 'fqa-on');
     }
     const audienceFqaMeta = document.createElement('meta');

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -410,11 +410,16 @@ function hideQuickActionsOnDevices() {
   document.body.dataset.device = userAgent.includes('Mobile') ? 'mobile' : 'desktop';
   const fqaMeta = document.createElement('meta');
   fqaMeta.setAttribute('content', 'on');
-  if (document.body.dataset.device === 'mobile'
-    || (/Safari/.test(userAgent) && !/Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent))) {
+  const isMobile = document.body.dataset.device === 'mobile';
+  const isQualifiedBrowser = (/Safari/.test(userAgent) && !/Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent));
+  if (isMobile || !isQualifiedBrowser) {
     fqaMeta.setAttribute('name', 'fqa-off');
   } else {
     fqaMeta.setAttribute('name', 'fqa-on');
+    const audienceFqaMeta = document.createElement('meta');
+    audienceFqaMeta.setAttribute('content', 'on');
+    audienceFqaMeta.setAttribute('name', isMobile ? 'mobile-fqa-qualified' : 'desktop-fqa-qualified');
+    document.head.append(audienceFqaMeta);
   }
   document.head.append(fqaMeta);
 }
@@ -440,7 +445,7 @@ export function preDecorateSections(area) {
             || urlParams.get(`${sectionMeta.showwith}`);
         }
         const showwith = sectionMeta.showwith.toLowerCase();
-        if ((showwith === 'fqa-off' || showwith === 'fqa-on')) hideQuickActionsOnDevices();
+        if (['fqa-off', 'fqa-on', 'mobile-fqa-qualified', 'desktop-fqa-qualified'].includes(showwith)) hideQuickActionsOnDevices();
         sectionRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(showwith) !== 'on';
       }
       if (sectionRemove) section.remove();

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -411,7 +411,7 @@ function hideQuickActionsOnDevices() {
   const fqaMeta = document.createElement('meta');
   fqaMeta.setAttribute('content', 'on');
   const isMobile = document.body.dataset.device === 'mobile';
-  const isQualifiedBrowser = (/Safari/.test(userAgent) && !/Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent));
+  const isQualifiedBrowser = !/Safari/.test(userAgent) || /Chrome|CriOS|FxiOS|Edg|OPR|Opera|OPiOS|Vivaldi|YaBrowser|Avast|VivoBrowser|GSA/.test(userAgent);
   if (isMobile || !isQualifiedBrowser) {
     fqaMeta.setAttribute('name', 'fqa-off');
   } else {

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -404,9 +404,8 @@ export function readBlockConfig(block) {
   return config;
 }
 
-function hideQuickActionsOnDevices() {
+export function hideQuickActionsOnDevices(userAgent) {
   if (getMetadata('fqa-off') || !!getMetadata('fqa-on')) return;
-  const { userAgent } = navigator;
   document.body.dataset.device = userAgent.includes('Mobile') ? 'mobile' : 'desktop';
   const fqaMeta = document.createElement('meta');
   fqaMeta.setAttribute('content', 'on');
@@ -450,7 +449,7 @@ export function preDecorateSections(area) {
             || urlParams.get(`${sectionMeta.showwith}`);
         }
         const showwith = sectionMeta.showwith.toLowerCase();
-        if (['fqa-off', 'fqa-on', 'fqa-non-qualified', 'fqa-qualified-mobile', 'fqa-qualified-desktop'].includes(showwith)) hideQuickActionsOnDevices();
+        if (['fqa-off', 'fqa-on', 'fqa-non-qualified', 'fqa-qualified-mobile', 'fqa-qualified-desktop'].includes(showwith)) hideQuickActionsOnDevices(navigator.userAgent);
         sectionRemove = showWithSearchParam !== null ? showWithSearchParam !== 'on' : getMetadata(showwith) !== 'on';
       }
       if (sectionRemove) section.remove();

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { setLibs } from '../../express/code/scripts/utils.js';
+import { setLibs, hideQuickActionsOnDevices } from '../../express/code/scripts/utils.js';
 
 describe('Libs', () => {
   it('Default Libs', () => {
@@ -41,5 +41,31 @@ describe('Libs', () => {
     };
     const libs = setLibs('/libs', location);
     expect(libs).to.equal('https://awesome--milo--forkedowner.aem.live/libs');
+  });
+});
+
+describe('Label Metadata for Frictionless', () => {
+  beforeEach(() => {
+    document.querySelector('meta[name="fqa-non-qualified"]')?.remove();
+    document.querySelector('meta[name="fqa-qualified-desktop"]')?.remove();
+    document.querySelector('meta[name="fqa-qualified-mobile"]')?.remove();
+    document.querySelector('meta[name="fqa-on"]')?.remove();
+    document.querySelector('meta[name="fqa-off"]')?.remove();
+  });
+  it('labels iOS as fqa-non-qualified', () => {
+    hideQuickActionsOnDevices('Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1');
+    expect(document.querySelector('meta[name="fqa-non-qualified"]')).to.exist;
+  });
+  it('labels desktop Safari as fqa-non-qualified', () => {
+    hideQuickActionsOnDevices('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Safari/605.1.15');
+    expect(document.querySelector('meta[name="fqa-non-qualified"]')).to.exist;
+  });
+  it('labels Android phone as fqa-qualified-mobile', () => {
+    hideQuickActionsOnDevices('Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36');
+    expect(document.querySelector('meta[name="fqa-qualified-mobile"]')).to.exist;
+  });
+  it('labels non-Safari desktop as fqa-qualified-desktop', () => {
+    hideQuickActionsOnDevices('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36');
+    expect(document.querySelector('meta[name="fqa-qualified-desktop"]')).to.exist;
   });
 });


### PR DESCRIPTION
Added 3 new authorable section-metadata`showwith=fqa-non-qualified`, `showwith=fqa-qualified-mobile` and `showwith=fqa-qualified-desktop` to replace `fqa-on` and `fqa-off`, but still keep it for backward compatibility for now.

Resolves: https://jira.corp.adobe.com/browse/MWPW-172485

How to test:
4 scenarios (Safari Desktop, non-Safari Desktop, Android Phone, non-Android Phone):
- Go to the branch url in each of the 4 device types
- On Safari Desktop and non-Android Phone, you should see the Columns block and no frictionless experience (ability to upload)
- On non-Safari Desktop, you should see the frictionless-quick-action block (upload dropzone)
- On Android Phone, you should see the frictionless-quick-action-mobile block (tap to upload)

Documentation: https://main--express-milo--adobecom.aem.live/docs/authoring/section-metadata/show-with (bottom)

Test URLs:
- Before: https://main--express-milo--adobecom.aem.live/drafts/esallee/transparent-copy?martech=off
- After: https://showwith-fqa-audience--express-milo--adobecom.aem.live/drafts/esallee/transparent-copy?martech=off

Regression:
- These urls should not be affected (different from prod) at all:
- https://showwith-fqa-audience--express-milo--adobecom.aem.live/express/feature/image/remove-background/clear?martech=off
- https://showwith-fqa-audience--express-milo--adobecom.aem.live/express/feature/image/remove-background?martech=off