### PR TITLE
[MWPW-171686] App Ratings Block URL Customization

### DIFF
--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -98,7 +98,6 @@ async function makeRatings(
 export default async function decorate(block) {
   // Dynamically import utilities from the shared library
   ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
-  console.log(getLibs());
   const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
   const [ratingPlaceholder,
     starsPlaceholder,

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -14,7 +14,8 @@ const GOOGLE = 'google';
  * @param {string} playStoreLabelPlaceholder - Placeholder for Play Store link aria-label
  * @param {string} appleStoreLabelPlaceholder - Placeholder for Apple Store link aria-label
  * @param {string} customURL - Optional custom URL for the store link
- * @returns {Promise<HTMLElement|null>} The ratings container element or null if no link is available
+ * @returns {Promise<HTMLElement|null>} The ratings container
+ *  element or null if no link is available
  */
 async function makeRating(
   store,

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -1,4 +1,3 @@
-
 import { getLibs, getMobileOperatingSystem, getIconElementDeprecated } from '../../scripts/utils.js';
 
 let createTag;

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -96,7 +96,6 @@ async function makeRatings(
  * @param {HTMLElement} block - The app ratings block element
  */
 export default async function decorate(block) {
-  // Dynamically import utilities from the shared library
   ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
   const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);
   const [ratingPlaceholder,
@@ -112,9 +111,9 @@ export default async function decorate(block) {
   );
 
   let customURL;
-  const content = block.querySelector(':scope > div a');
-  if (content) {
-    customURL = content.getAttribute('href');
+  const customUrlElement = block.querySelector(':scope > div a');
+  if (customUrlElement) {
+    customURL =  customUrlElement.getAttribute('href');
   }
 
   block.append(await makeRatings(
@@ -125,7 +124,7 @@ export default async function decorate(block) {
     customURL,
   ));
 
-  if (content) {
-    content.remove();
+  if (customUrlElement) {
+    customUrlElement.remove();
   }
 }

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -113,7 +113,7 @@ export default async function decorate(block) {
   let customURL;
   const customUrlElement = block.querySelector(':scope > div a');
   if (customUrlElement) {
-    customURL =  customUrlElement.getAttribute('href');
+    customURL = customUrlElement.getAttribute('href');
   }
 
   block.append(await makeRatings(
@@ -121,7 +121,7 @@ export default async function decorate(block) {
     starsPlaceholder,
     playStoreLabelPlaceholder,
     appleStoreLabelPlaceholder,
-    customURL
+    customURL,
   ));
 
   if (customUrlElement) {

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -6,17 +6,6 @@ let getConfig;
 const APPLE = 'apple';
 const GOOGLE = 'google';
 
-/**
- * Creates a ratings container for a specific store (Apple or Google)
- * @param {string} store - 'apple' or 'google'
- * @param {string} ratingPlaceholder - Placeholder string for ratings (e.g., '4.8, 1M; 4.7, 2M; https://store.link')
- * @param {string} starsPlaceholder - Placeholder for the aria-label of the star icon
- * @param {string} playStoreLabelPlaceholder - Placeholder for Play Store link aria-label
- * @param {string} appleStoreLabelPlaceholder - Placeholder for Apple Store link aria-label
- * @param {string} customURL - Optional custom URL for the store link
- * @returns {Promise<HTMLElement|null>} The ratings container
- *  element or null if no link is available
- */
 async function makeRating(
   store,
   ratingPlaceholder,
@@ -47,15 +36,6 @@ async function makeRating(
   return createTag('div', { class: 'ratings-container' }, [score, star, cnt, storeLink]);
 }
 
-/**
- * Creates the ratings block for both Apple and Google stores, depending on device
- * @param {string} ratingPlaceholder
- * @param {string} starsPlaceholder
- * @param {string} playStoreLabelPlaceholder
- * @param {string} appleStoreLabelPlaceholder
- * @param {string} customURL
- * @returns {Promise<HTMLElement>} The ratings block element
- */
 async function makeRatings(
   ratingPlaceholder,
   starsPlaceholder,
@@ -90,11 +70,6 @@ async function makeRatings(
   return ratings;
 }
 
-/**
- * Main decorator function for the app ratings block
- * Dynamically loads utilities, fetches placeholders, and renders the ratings UI
- * @param {HTMLElement} block - The app ratings block element
- */
 export default async function decorate(block) {
   ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
   const { replaceKey } = await import(`${getLibs()}/features/placeholders.js`);

--- a/express/code/blocks/app-ratings/app-ratings.js
+++ b/express/code/blocks/app-ratings/app-ratings.js
@@ -121,7 +121,7 @@ export default async function decorate(block) {
     starsPlaceholder,
     playStoreLabelPlaceholder,
     appleStoreLabelPlaceholder,
-    customURL,
+    customURL
   ));
 
   if (customUrlElement) {

--- a/test/blocks/app-ratings/app-ratings.test.js
+++ b/test/blocks/app-ratings/app-ratings.test.js
@@ -25,6 +25,10 @@ describe('App Ratings', () => {
     };
   });
 
+  after(async () => {
+    document.body.innerHTML = '';
+  });
+
   it('App Ratings exists', async () => {
     const blocks = document.getElementsByClassName('app-ratings');
     expect(blocks.length).to.equal(1);

--- a/test/blocks/app-ratings/app-ratings.test.js
+++ b/test/blocks/app-ratings/app-ratings.test.js
@@ -1,4 +1,6 @@
 import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 window.isTestEnv = true;
 const imports = await Promise.all([import('../../../express/code/scripts/utils.js'), import('../../../express/code/scripts/scripts.js')]);

--- a/test/blocks/app-ratings/app-ratings.test.js
+++ b/test/blocks/app-ratings/app-ratings.test.js
@@ -1,6 +1,4 @@
 import { readFile } from '@web/test-runner-commands';
-import { expect } from '@esm-bundle/chai';
-
 const locales = { '': { ietf: 'en-US', tk: 'hah7vzn.css' } };
 window.isTestEnv = true;
 const imports = await Promise.all([import('../../../express/code/scripts/utils.js'), import('../../../express/code/scripts/scripts.js')]);
@@ -11,23 +9,27 @@ await import(`${getLibs()}/utils/utils.js`).then((mod) => {
   mod.setConfig(conf);
 });
 const { default: decorate } = await import('../../../express/code/blocks/app-ratings/app-ratings.js');
-const body = await readFile({ path: './mocks/body.html' });
-document.body.innerHTML = body;
+
 describe('App Ratings', () => {
-  before(() => {
+  before(async () => {
+    const body = await readFile({ path: './mocks/body.html' });
+    document.body.innerHTML = body;
     window.isTestEnv = true;
     window.placeholders = {
-      'app-store-ratings': 'Test',
-      'app-store-stars': 'Test',
-      'app-store-ratings-play-store': 'Test',
-      'app-store-ratings-apple-store': 'Test',
+      'app-store-ratings': '4.9, 233.8k ratings; 4.6, 117k ratings; https://adobesparkpost.app.link/GJrBPFUWBBb',
+      'app-store-stars': 'Stars',
+      'app-store-ratings-play-store': 'app-store-ratings-play-store',
+      'app-store-ratings-apple-store': 'app-store-ratings-apple-store',
     };
   });
 
   it('App Ratings exists', async () => {
-    const block = document.getElementsByClassName('app-ratings')[0];
-    await decorate(block);
-    const googleRating = block.querySelector('.ratings');
-    expect(googleRating).to.exist;
+    const blocks = document.getElementsByClassName('app-ratings');
+    expect(blocks.length).to.equal(1);
+    for (const block of blocks) {
+      await decorate(block);
+      const googleRating = block.querySelector('.ratings');
+      expect(googleRating).to.exist;
+    }
   });
 });


### PR DESCRIPTION
Describe your specific features or fixes

Allows the user to add a single customized URL to the independent `app-ratings` block.

Resolves: https://jira.corp.adobe.com/projects/MWPW/issues/MWPW-171686

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After:  https://app-rating-block-enhancement--express-milo--adobecom.hlx.page/drafts/echen/app-ratings

Test Instructions:

Use the app ratings block at the bottom of the demo page above and verify it takes you to www.stage.adobe.com
