### PR TITLE
Ax columns video bug

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1164,6 +1164,7 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
     max-width: 600px;
     height: 100%;
     position: relative;
+    clip-path: inset(1px 1px);
   }
 
   .ax-columns.fullsize + h2 {

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1152,7 +1152,6 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
 
   .ax-columns.fullsize .column.hero-animation-overlay {
     position: relative;
-    height: 610px;
   }
 
   .ax-columns.fullsize .column.columns-picture > p,
@@ -1161,9 +1160,10 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   }
 
   .ax-columns.fullsize .column video {
-    position: absolute;
     left: 0;
     max-width: 600px;
+    height: 100%;
+    position: relative;
   }
 
   .ax-columns.fullsize + h2 {


### PR DESCRIPTION
Describe your specific features or fixes

Removes the absolute positioning and static height of video elements in `ax-columns.fullsize`. 

Resolves: https://jira.corp.adobe.com/browse/MWPW-172865

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://ax-columns-video-bug--express-milo--adobecom.hlx.page/drafts/esallee/switch-now-marquee-video-bug
