### PR TITLE
[MWPW-172614] Extra Spacing In Gen AI Homepage Cards

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -67,7 +67,6 @@
 
 .gen-ai-cards.homepage {
   max-width: unset;
-  padding-left: 0;
   gap: unset;
   padding-right: 0;
   --color-border: rgb(225, 225, 225); 

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -579,7 +579,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right.arrow-hidd
   }
 
   .gen-ai-cards.homepage .carousel-container .carousel-element.card:nth-child(2) {
-    margin-left: 16px;
+    margin-left: var(--spacing-300);
   }
 
   .gen-ai-cards .carousel-container .carousel-fader-left,

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -579,7 +579,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right.arrow-hidd
   }
 
   .gen-ai-cards.homepage .carousel-container .carousel-element.card:nth-child(2) {
-    margin-left: 8px;
+    margin-left: 16px;
   }
 
   .gen-ai-cards .carousel-container .carousel-fader-left,

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -69,6 +69,7 @@
   max-width: unset;
   gap: unset;
   padding-right: 0;
+  padding-left: 0;
   --color-border: rgb(225, 225, 225); 
   --color-background-light : rbg(255,255,255)
 }

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -174,8 +174,6 @@
 }
 
 .gen-ai-cards.homepage .carousel-element.card {
-  /* width: var(--card-width); */
-  height: 396px;
   flex-direction: column;
 }
 
@@ -598,8 +596,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right.arrow-hidd
   }
 
   .gen-ai-cards.homepage .carousel-element.card {
-    width: var(--card-width-desktop);
-    height: var(--card-height-desktop);
+    width: var(--card-width-desktop); 
   }
 
   .gen-ai-cards.homepage .card .text-wrapper {


### PR DESCRIPTION
Describe your specific features or fixes

Removes static height setting that was causing extra spacing in gen ai homepage cards.

Resolves:  https://jira.corp.adobe.com/browse/MWPW-172614

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: 
- https://homepage-visual-fix--express-milo--adobecom.hlx.page/uk/express/spotlight/designwithexpress
- https://homepage-visual-fix--express-milo--adobecom.hlx.page/express/ai
- https://homepage-visual-fix--express-milo--adobecom.hlx.page/express/

Test Instructions
 For the first link, visit and verify the spacing is gone in the gen ai cards on desktop, mobile + tablet.
 For the 2nd and third link, verify there is no visual regression on the branch vs prod.
<img width="1714" alt="Screenshot 2025-05-05 at 11 44 12 AM" src="https://github.com/user-attachments/assets/306e5961-b030-4264-a19a-39240e5de759" />

