### PR TITLE
[Q2 FY25] | UK LP Update Block for Tablet

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1152,6 +1152,10 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   .content.columns-xl-heading h6 {
     font-size: var(--heading-font-size-m);
   }
+  
+  .ax-columns.width-2-columns:nth-of-type(odd) > div {
+    flex-direction: row-reverse;
+  }
 }
 
 @media (min-width: 1200px) {

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -879,6 +879,28 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
     padding: 0 55px 60px;
     max-width: 1100px;
   }
+  .section .ax-columns {
+    max-width: unset;
+  }
+  .section .ax-columns > div {
+    display: flex;
+    flex-direction: row;
+    text-align: left;
+    align-items: center;
+  }
+  .section div.ax-columns > div {
+    position: relative;
+  }
+  .section div.ax-columns > div > div {
+    width: 50%;
+    box-sizing: border-box;
+  }
+  .section div.ax-columns > div > div:only-child {
+    width: 100%;
+  }
+  .ax-columns.width-2-columns > .columns-video:nth-child(even) {
+    flex-direction: row-reverse;
+  }
 }
 
 @media (min-width: 900px) and (max-width: 1200px) {


### PR DESCRIPTION
Describe your specific features or fixes:
* Update layout so that on tablet the columns block displays the first column as text -> video and the next row as video -> text - similar to desktop
* Mobile remains the same with a stacked layout

Resolves: [MWPW-170814](https://jira.corp.adobe.com/browse/MWPW-170814)

**Before**:
<img width="726" alt="before" src="https://github.com/user-attachments/assets/71396ccd-3776-4144-98af-f5855d80e40a" />

**After**:
<img width="728" alt="tablet" src="https://github.com/user-attachments/assets/64c5b91d-2b0c-43b5-94c9-d02bddd4dcf5" />


Test URLs:
- Before: https://main--express-milo--adobecom.aem.page/uk/drafts/jsandlan/uk-columns-tablet
- After: https://milo-uk-update-block--express-milo--adobecom.hlx.page/uk/drafts/jsandlan/uk-columns-tablet
