### PR TITLE
MWPW-169102-169103-169104: set approximate width and height to avoid trash layout

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -705,7 +705,7 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
 .ax-columns.fullsize .hero-animation-overlay {
   padding-top: 4px;
   padding-bottom: 4px;
-  height: var(--hero-animation-overlay-video-height);
+  min-height: var(--hero-animation-overlay-video-height);
 }
 
 .ax-columns.fullsize .hero-animation-overlay video {

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1,3 +1,7 @@
+:root {
+  --hero-animation-overlay-video-height: 430px;
+}
+
 .section:first-child .ax-columns:first-child {
   min-height: unset;
 }
@@ -701,6 +705,7 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
 .ax-columns.fullsize .hero-animation-overlay {
   padding-top: 4px;
   padding-bottom: 4px;
+  height: var(--hero-animation-overlay-video-height);
 }
 
 .ax-columns.fullsize .hero-animation-overlay video {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -59,7 +59,7 @@
 
 .frictionless-quick-action .fqa-container .button-container.hero-animation-overlay {
     width: var(--frictionless-quick-action-video-width);
-    height: var(--frictionless-quick-action-video-height);
+    min-height: var(--frictionless-quick-action-video-height);
 }
 
 .frictionless-quick-action .fqa-container > div:nth-child(2) {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -1,3 +1,8 @@
+:root {
+    --frictionless-quick-action-video-width: 444px;
+    --frictionless-quick-action-video-height: 455px;
+}
+
 .frictionless-quick-action {
     padding: 40px 20px;
     max-width: none;
@@ -52,13 +57,18 @@
     flex-wrap: wrap;
 }
 
+.frictionless-quick-action .fqa-container .button-container.hero-animation-overlay {
+    width: var(--frictionless-quick-action-video-width);
+    height: var(--frictionless-quick-action-video-height);
+}
+
 .frictionless-quick-action .fqa-container > div:nth-child(2) {
     margin-top: 26px;
 }
 
 .frictionless-quick-action video,
 .frictionless-quick-action img:not(.icon) {
-    max-width: 444px;
+    max-width: var(--frictionless-quick-action-video-width);
 }
 
 .frictionless-quick-action .dropzone-container {


### PR DESCRIPTION
There is a layout trash happening since the video is dynamically injected and dimensions of elements are set and then reset. We can see this more obvious on mobile view. 

* Set the approximate video dimensions for the container to reserve the space.

Resolves: [MWPW-169102](https://jira.corp.adobe.com/browse/MWPW-169102),  [MWPW-169103](https://jira.corp.adobe.com/browse/MWPW-169103),  [MWPW-169104](https://jira.corp.adobe.com/browse/MWPW-169104)

Test URLs: 
US locale:
[MWPW-169102](https://jira.corp.adobe.com/browse/MWPW-169102)
- Before: https://main--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off
- After: https://mwpw-169103--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off

[MWPW-169103](https://jira.corp.adobe.com/browse/MWPW-169103)
- Before: https://main--express-milo--adobecom.aem.page/in/express/feature/image/remove-background?martech=off
- After: https://mwpw-169103--express-milo--adobecom.aem.page/in/express/feature/image/remove-background?martech=off

IN locale:
[MWPW-169104](https://jira.corp.adobe.com/browse/MWPW-169104)
- Before: https://main--express-milo--adobecom.aem.page/express/feature/image/resize?martech=off
- After: https://mwpw-169103--express-milo--adobecom.aem.page/express/feature/image/reresize?martech=off
