### PR TITLE
[MWPW-172777] Fix For Pricing Table Collapse

### DIFF
--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -29,6 +29,10 @@
   margin-right: 8px;
 }
 
+.pricing-table .additional-row.collapsed {
+  display: none;
+}
+
 /* links stay links by default in cells */
 .pricing-table .row:not(.row-heading) .col a.button,
 .pricing-table .row:not(.row-heading) .col a.button:hover,
@@ -170,6 +174,7 @@
   .pricing-table.single-section .col-wrapper {
     height: 36px;
   }
+
   .pricing-table.single-section .additional-row .col-2.collapsed,
   .pricing-table.single-section .additional-row .col-3.collapsed {
     display: none;

--- a/test/blocks/pricing-table/mocks/body.html
+++ b/test/blocks/pricing-table/mocks/body.html
@@ -1,0 +1,104 @@
+<div class="pricing-table sticky-show3 vertical-header vertical-shading">
+    <div>
+      <div>Compare tiers</div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=webply&amp;optimize=medium">
+            <source type="image/png" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="Premium Icon: adobe-express-rebrand-logo" src="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=png&amp;optimize=medium" width="33" height="33">
+          </picture>
+        </p>
+        <p>Champion</p>
+      </div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=webply&amp;optimize=medium">
+            <source type="image/png" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="Premium Icon: adobe-express-rebrand-logo" src="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=png&amp;optimize=medium" width="33" height="33">
+          </picture>
+        </p>
+        <p>Icon</p>
+      </div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=webply&amp;optimize=medium">
+            <source type="image/png" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="Premium Icon: adobe-express-rebrand-logo" src="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=png&amp;optimize=medium" width="33" height="33">
+          </picture>
+        </p>
+        <p>Legend</p>
+      </div>
+    </div>
+    <div>
+      <div></div>
+    </div>
+    <div>
+      <div>Test Header</div>
+    </div>
+    <div>
+      <div>Follow requirements</div>
+      <div>
+        <p>+</p>
+        <p>10k-100k reach</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>100k-250k reach</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>250k+ reach</p>
+      </div>
+    </div>
+    <div>
+      <div>Adobe Express swag</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Early access to new features</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Access to product feedback loop</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Exclusive space for conversation with ambassadors and Adobe</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Paid opportunities</div>
+      <div>
+        <p>+</p>
+        <p>Up to $500</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>Up to $1,000</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>Up to $1,500</p>
+      </div>
+    </div>
+    <div>
+      <div>Yearly Adobe Creative Cloud Membership</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+  </div>

--- a/test/blocks/pricing-table/mocks/single-section.html
+++ b/test/blocks/pricing-table/mocks/single-section.html
@@ -1,0 +1,104 @@
+<div class="pricing-table single-section sticky-show3 vertical-header vertical-shading">
+    <div>
+      <div>Compare tiers</div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=webply&amp;optimize=medium">
+            <source type="image/png" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="Premium Icon: adobe-express-rebrand-logo" src="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=png&amp;optimize=medium" width="33" height="33">
+          </picture>
+        </p>
+        <p>Champion</p>
+      </div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=webply&amp;optimize=medium">
+            <source type="image/png" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="Premium Icon: adobe-express-rebrand-logo" src="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=png&amp;optimize=medium" width="33" height="33">
+          </picture>
+        </p>
+        <p>Icon</p>
+      </div>
+      <div>
+        <p>
+          <picture>
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=webply&amp;optimize=medium" media="(min-width: 600px)">
+            <source type="image/webp" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=webply&amp;optimize=medium">
+            <source type="image/png" srcset="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=2000&amp;format=png&amp;optimize=medium" media="(min-width: 600px)">
+            <img loading="lazy" alt="Premium Icon: adobe-express-rebrand-logo" src="./media_1b980eef977b522fb5ca1f2bcf70538a8df8b0942.png?width=750&amp;format=png&amp;optimize=medium" width="33" height="33">
+          </picture>
+        </p>
+        <p>Legend</p>
+      </div>
+    </div>
+    <div>
+      <div></div>
+    </div>
+    <div>
+      <div>Test Header</div>
+    </div>
+    <div>
+      <div>Follow requirements</div>
+      <div>
+        <p>+</p>
+        <p>10k-100k reach</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>100k-250k reach</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>250k+ reach</p>
+      </div>
+    </div>
+    <div>
+      <div>Adobe Express swag</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Early access to new features</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Access to product feedback loop</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Exclusive space for conversation with ambassadors and Adobe</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+    <div>
+      <div>Paid opportunities</div>
+      <div>
+        <p>+</p>
+        <p>Up to $500</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>Up to $1,000</p>
+      </div>
+      <div>
+        <p>+</p>
+        <p>Up to $1,500</p>
+      </div>
+    </div>
+    <div>
+      <div>Yearly Adobe Creative Cloud Membership</div>
+      <div>+</div>
+      <div>+</div>
+      <div>+</div>
+    </div>
+  </div>

--- a/test/blocks/pricing-table/pricing-table.test.js
+++ b/test/blocks/pricing-table/pricing-table.test.js
@@ -7,11 +7,12 @@ const imports = await Promise.all([
 ]);
 
 const { default: decorate } = imports[1];
-const testBody = await readFile({ path: './mocks/body.html' });
+
 
 describe('Pricing Table', () => {
   let block;
   before(async () => {
+    const testBody = await readFile({ path: './mocks/body.html' });
     window.isTestEnv = true;
     document.body.innerHTML = testBody;
     window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
@@ -20,6 +21,7 @@ describe('Pricing Table', () => {
   });
   afterEach(() => {
     window.placeholders = undefined;
+    document.body.innerHTML = '';
   });
 
   it('should render the correct number of rows', async () => {
@@ -84,3 +86,72 @@ describe('Pricing Table', () => {
     expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(0);
   });
 });
+
+describe('Pricing Table Single Section', () => {
+    let block;
+    before(async () => {
+        const testBody = await readFile({ path: './mocks/single-section.html' });
+      window.isTestEnv = true;
+      document.body.innerHTML = testBody;
+      window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
+      await decorate(document.querySelector('.pricing-table'));
+      block = document.querySelector('.pricing-table-wrapper');
+    });
+    afterEach(() => {
+      window.placeholders = undefined;
+        document.body.innerHTML = '';
+    });
+  
+    it('should render the correct number of rows', async () => {
+      const rows = block.querySelectorAll('.pricing-table > .row');
+      expect(rows.length).to.equal(10);
+    });
+  
+    it('should have a header row with "Compare tiers" and tier names', async () => {
+      const headerRow = block.querySelector('.row-heading');
+      expect(headerRow).to.exist;
+      expect(headerRow.querySelector('.col-1').textContent).to.equal('Compare tiers');
+      const tierColumns = headerRow.querySelectorAll('.col-heading:nth-child(n+2)');
+      const tierNames = Array.from(tierColumns).map((col) => col.textContent.trim());
+      expect(tierNames).to.deep.equal(['Champion', 'Icon', 'Legend']);
+    });
+  
+    it('should have section header rows', async () => {
+      const sectionHeaders = block.querySelectorAll('.section-header-row .section-head-title');
+      const expectedHeaders = ['Test Header'];
+      const actualHeaders = Array.from(sectionHeaders).map((header) => header.textContent);
+      expect(actualHeaders).to.deep.equal(expectedHeaders);
+    });
+  
+    it('should have feature rows with descriptions', async () => {
+      const featureRows = block.querySelectorAll('.section-row:not(.shaded):not(.section-header-row)');
+      expect(featureRows.length).to.equal(3);
+    });
+  
+    it('should have additional rows with descriptions', async () => {
+      const additionalRows = block.querySelectorAll('.additional-row');
+      expect(additionalRows.length).to.equal(4);
+    });
+  
+    it('should have include indicators for features', async () => {
+      const includedFeatures = block.querySelectorAll('.included-feature');
+      expect(includedFeatures.length).to.be.greaterThan(0);
+      includedFeatures.forEach((feature) => {
+        expect(feature.querySelector('.feat-icon.check') || feature.querySelector('p:not(.icon-container)')).to.exist;
+      });
+    });
+  
+    it('should have a "View all features" toggle button', async () => {
+      const toggleButton = block.querySelector('.toggle-row');
+      expect(toggleButton).to.exist;
+      expect(toggleButton.textContent.trim()).to.equal('view all features');
+      toggleButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      toggleButton.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      }));
+      expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(0);
+     
+    });
+  });

--- a/test/blocks/pricing-table/pricing-table.test.js
+++ b/test/blocks/pricing-table/pricing-table.test.js
@@ -8,150 +8,118 @@ const imports = await Promise.all([
 
 const { default: decorate } = imports[1];
 
+// Shared test setup
+const setupTest = async (htmlFile) => {
+  const testBody = await readFile({ path: htmlFile });
+  window.isTestEnv = true;
+  document.body.innerHTML = testBody;
+  window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
+  await decorate(document.querySelector('.pricing-table'));
+  return document.querySelector('.pricing-table-wrapper');
+};
+
+// Shared test cleanup
+const cleanupTest = () => {
+  window.placeholders = undefined;
+  document.body.innerHTML = '';
+};
+
+// Shared assertions
+const assertHeaderRow = (block) => {
+  const headerRow = block.querySelector('.row-heading');
+  expect(headerRow).to.exist;
+  expect(headerRow.querySelector('.col-1').textContent).to.equal('Compare tiers');
+  const tierColumns = headerRow.querySelectorAll('.col-heading:nth-child(n+2)');
+  const tierNames = Array.from(tierColumns).map((col) => col.textContent.trim());
+  expect(tierNames).to.deep.equal(['Champion', 'Icon', 'Legend']);
+};
+
+const assertSectionHeaders = (block) => {
+  const sectionHeaders = block.querySelectorAll('.section-header-row .section-head-title');
+  const expectedHeaders = ['Test Header'];
+  const actualHeaders = Array.from(sectionHeaders).map((header) => header.textContent);
+  expect(actualHeaders).to.deep.equal(expectedHeaders);
+};
+
+const assertFeatureRows = (block) => {
+  const featureRows = block.querySelectorAll('.section-row:not(.shaded):not(.section-header-row)');
+  expect(featureRows.length).to.equal(3);
+};
+
+const assertAdditionalRows = (block) => {
+  const additionalRows = block.querySelectorAll('.additional-row');
+  expect(additionalRows.length).to.equal(4);
+};
+
+const assertIncludedFeatures = (block) => {
+  const includedFeatures = block.querySelectorAll('.included-feature');
+  expect(includedFeatures.length).to.be.greaterThan(0);
+  includedFeatures.forEach((feature) => {
+    expect(feature.querySelector('.feat-icon.check') || feature.querySelector('p:not(.icon-container)')).to.exist;
+  });
+};
+
+const assertToggleButton = async (block) => {
+  const toggleButton = block.querySelector('.toggle-row');
+  expect(toggleButton).to.exist;
+  expect(toggleButton.textContent.trim()).to.equal('view all features');
+  
+  // Test toggle functionality
+  toggleButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  toggleButton.dispatchEvent(new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+  }));
+  expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(4);
+  
+  toggleButton.dispatchEvent(new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+  }));
+  expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(0);
+};
 
 describe('Pricing Table', () => {
   let block;
+  
   before(async () => {
-    const testBody = await readFile({ path: './mocks/body.html' });
-    window.isTestEnv = true;
-    document.body.innerHTML = testBody;
-    window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
-    await decorate(document.querySelector('.pricing-table'));
-    block = document.querySelector('.pricing-table-wrapper');
+    block = await setupTest('./mocks/body.html');
   });
-  afterEach(() => {
-    window.placeholders = undefined;
-    document.body.innerHTML = '';
-  });
+  
+  afterEach(cleanupTest);
 
   it('should render the correct number of rows', async () => {
     const rows = block.querySelectorAll('.pricing-table > .row');
     expect(rows.length).to.equal(11);
   });
 
-  it('should have a header row with "Compare tiers" and tier names', async () => {
-    const headerRow = block.querySelector('.row-heading');
-    expect(headerRow).to.exist;
-    expect(headerRow.querySelector('.col-1').textContent).to.equal('Compare tiers');
-    const tierColumns = headerRow.querySelectorAll('.col-heading:nth-child(n+2)');
-    const tierNames = Array.from(tierColumns).map((col) => col.textContent.trim());
-    expect(tierNames).to.deep.equal(['Champion', 'Icon', 'Legend']);
-  });
-
-  it('should have section header rows', async () => {
-    const sectionHeaders = block.querySelectorAll('.section-header-row .section-head-title');
-    const expectedHeaders = ['Test Header'];
-    const actualHeaders = Array.from(sectionHeaders).map((header) => header.textContent);
-    expect(actualHeaders).to.deep.equal(expectedHeaders);
-  });
-
-  it('should have feature rows with descriptions', async () => {
-    const featureRows = block.querySelectorAll('.section-row:not(.shaded):not(.section-header-row)');
-    expect(featureRows.length).to.equal(3);
-  });
-
-  it('should have additional rows with descriptions', async () => {
-    const additionalRows = block.querySelectorAll('.additional-row');
-    expect(additionalRows.length).to.equal(4);
-  });
-
-  it('should have include indicators for features', async () => {
-    const includedFeatures = block.querySelectorAll('.included-feature');
-    expect(includedFeatures.length).to.be.greaterThan(0);
-    includedFeatures.forEach((feature) => {
-      expect(feature.querySelector('.feat-icon.check') || feature.querySelector('p:not(.icon-container)')).to.exist;
-    });
-  });
-
-  it('should have a "View all features" toggle button', async () => {
-    const toggleButton = block.querySelector('.toggle-row');
-    expect(toggleButton).to.exist;
-    expect(toggleButton.textContent.trim()).to.equal('view all features');
-    toggleButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    toggleButton.dispatchEvent(new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-    }));
-    expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(4);
-    toggleButton.dispatchEvent(new KeyboardEvent('keydown', {
-      key: 'Enter',
-      code: 'Enter',
-      keyCode: 13,
-      which: 13,
-      bubbles: true,
-      cancelable: true,
-      view: window,
-    }));
-    expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(0);
-  });
+  it('should have a header row with "Compare tiers" and tier names', () => assertHeaderRow(block));
+  it('should have section header rows', () => assertSectionHeaders(block));
+  it('should have feature rows with descriptions', () => assertFeatureRows(block));
+  it('should have additional rows with descriptions', () => assertAdditionalRows(block));
+  it('should have include indicators for features', () => assertIncludedFeatures(block));
+  it('should have a "View all features" toggle button', () => assertToggleButton(block));
 });
 
 describe('Pricing Table Single Section', () => {
-    let block;
-    before(async () => {
-        const testBody = await readFile({ path: './mocks/single-section.html' });
-      window.isTestEnv = true;
-      document.body.innerHTML = testBody;
-      window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
-      await decorate(document.querySelector('.pricing-table'));
-      block = document.querySelector('.pricing-table-wrapper');
-    });
-    afterEach(() => {
-      window.placeholders = undefined;
-        document.body.innerHTML = '';
-    });
+  let block;
   
-    it('should render the correct number of rows', async () => {
-      const rows = block.querySelectorAll('.pricing-table > .row');
-      expect(rows.length).to.equal(10);
-    });
-  
-    it('should have a header row with "Compare tiers" and tier names', async () => {
-      const headerRow = block.querySelector('.row-heading');
-      expect(headerRow).to.exist;
-      expect(headerRow.querySelector('.col-1').textContent).to.equal('Compare tiers');
-      const tierColumns = headerRow.querySelectorAll('.col-heading:nth-child(n+2)');
-      const tierNames = Array.from(tierColumns).map((col) => col.textContent.trim());
-      expect(tierNames).to.deep.equal(['Champion', 'Icon', 'Legend']);
-    });
-  
-    it('should have section header rows', async () => {
-      const sectionHeaders = block.querySelectorAll('.section-header-row .section-head-title');
-      const expectedHeaders = ['Test Header'];
-      const actualHeaders = Array.from(sectionHeaders).map((header) => header.textContent);
-      expect(actualHeaders).to.deep.equal(expectedHeaders);
-    });
-  
-    it('should have feature rows with descriptions', async () => {
-      const featureRows = block.querySelectorAll('.section-row:not(.shaded):not(.section-header-row)');
-      expect(featureRows.length).to.equal(3);
-    });
-  
-    it('should have additional rows with descriptions', async () => {
-      const additionalRows = block.querySelectorAll('.additional-row');
-      expect(additionalRows.length).to.equal(4);
-    });
-  
-    it('should have include indicators for features', async () => {
-      const includedFeatures = block.querySelectorAll('.included-feature');
-      expect(includedFeatures.length).to.be.greaterThan(0);
-      includedFeatures.forEach((feature) => {
-        expect(feature.querySelector('.feat-icon.check') || feature.querySelector('p:not(.icon-container)')).to.exist;
-      });
-    });
-  
-    it('should have a "View all features" toggle button', async () => {
-      const toggleButton = block.querySelector('.toggle-row');
-      expect(toggleButton).to.exist;
-      expect(toggleButton.textContent.trim()).to.equal('view all features');
-      toggleButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      toggleButton.dispatchEvent(new MouseEvent('click', {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-      }));
-      expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(0);
-     
-    });
+  before(async () => {
+    block = await setupTest('./mocks/single-section.html');
   });
+  
+  afterEach(cleanupTest);
+
+  it('should render the correct number of rows', async () => {
+    const rows = block.querySelectorAll('.pricing-table > .row');
+    expect(rows.length).to.equal(10);
+  });
+
+  it('should have a header row with "Compare tiers" and tier names', () => assertHeaderRow(block));
+  it('should have section header rows', () => assertSectionHeaders(block));
+  it('should have feature rows with descriptions', () => assertFeatureRows(block));
+  it('should have additional rows with descriptions', () => assertAdditionalRows(block));
+  it('should have include indicators for features', () => assertIncludedFeatures(block));
+});

--- a/test/blocks/pricing-table/pricing-table.test.js
+++ b/test/blocks/pricing-table/pricing-table.test.js
@@ -63,7 +63,7 @@ const assertToggleButton = async (block) => {
   const toggleButton = block.querySelector('.toggle-row');
   expect(toggleButton).to.exist;
   expect(toggleButton.textContent.trim()).to.equal('view all features');
-  
+
   // Test toggle functionality
   toggleButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
   toggleButton.dispatchEvent(new MouseEvent('click', {
@@ -72,7 +72,7 @@ const assertToggleButton = async (block) => {
     view: window,
   }));
   expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(4);
-  
+
   toggleButton.dispatchEvent(new MouseEvent('click', {
     bubbles: true,
     cancelable: true,
@@ -83,11 +83,11 @@ const assertToggleButton = async (block) => {
 
 describe('Pricing Table', () => {
   let block;
-  
+
   before(async () => {
     block = await setupTest('./mocks/body.html');
   });
-  
+
   afterEach(cleanupTest);
 
   it('should render the correct number of rows', async () => {
@@ -105,11 +105,11 @@ describe('Pricing Table', () => {
 
 describe('Pricing Table Single Section', () => {
   let block;
-  
+
   before(async () => {
     block = await setupTest('./mocks/single-section.html');
   });
-  
+
   afterEach(cleanupTest);
 
   it('should render the correct number of rows', async () => {

--- a/test/blocks/pricing-table/pricing-table.test.js
+++ b/test/blocks/pricing-table/pricing-table.test.js
@@ -1,0 +1,86 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+const imports = await Promise.all([
+  import('../../../express/code/scripts/scripts.js'),
+  import('../../../express/code/blocks/pricing-table/pricing-table.js'),
+]);
+
+const { default: decorate } = imports[1];
+const testBody = await readFile({ path: './mocks/body.html' });
+
+describe('Pricing Table', () => {
+  let block;
+  before(async () => {
+    window.isTestEnv = true;
+    document.body.innerHTML = testBody;
+    window.placeholders = { 'search-branch-links': 'https://adobesparkpost.app.link/c4bWARQhWAb' };
+    await decorate(document.querySelector('.pricing-table'));
+    block = document.querySelector('.pricing-table-wrapper');
+  });
+  afterEach(() => {
+    window.placeholders = undefined;
+  });
+
+  it('should render the correct number of rows', async () => {
+    const rows = block.querySelectorAll('.pricing-table > .row');
+    expect(rows.length).to.equal(11);
+  });
+
+  it('should have a header row with "Compare tiers" and tier names', async () => {
+    const headerRow = block.querySelector('.row-heading');
+    expect(headerRow).to.exist;
+    expect(headerRow.querySelector('.col-1').textContent).to.equal('Compare tiers');
+    const tierColumns = headerRow.querySelectorAll('.col-heading:nth-child(n+2)');
+    const tierNames = Array.from(tierColumns).map((col) => col.textContent.trim());
+    expect(tierNames).to.deep.equal(['Champion', 'Icon', 'Legend']);
+  });
+
+  it('should have section header rows', async () => {
+    const sectionHeaders = block.querySelectorAll('.section-header-row .section-head-title');
+    const expectedHeaders = ['Test Header'];
+    const actualHeaders = Array.from(sectionHeaders).map((header) => header.textContent);
+    expect(actualHeaders).to.deep.equal(expectedHeaders);
+  });
+
+  it('should have feature rows with descriptions', async () => {
+    const featureRows = block.querySelectorAll('.section-row:not(.shaded):not(.section-header-row)');
+    expect(featureRows.length).to.equal(3);
+  });
+
+  it('should have additional rows with descriptions', async () => {
+    const additionalRows = block.querySelectorAll('.additional-row');
+    expect(additionalRows.length).to.equal(4);
+  });
+
+  it('should have include indicators for features', async () => {
+    const includedFeatures = block.querySelectorAll('.included-feature');
+    expect(includedFeatures.length).to.be.greaterThan(0);
+    includedFeatures.forEach((feature) => {
+      expect(feature.querySelector('.feat-icon.check') || feature.querySelector('p:not(.icon-container)')).to.exist;
+    });
+  });
+
+  it('should have a "View all features" toggle button', async () => {
+    const toggleButton = block.querySelector('.toggle-row');
+    expect(toggleButton).to.exist;
+    expect(toggleButton.textContent.trim()).to.equal('view all features');
+    toggleButton.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    toggleButton.dispatchEvent(new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    }));
+    expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(4);
+    toggleButton.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Enter',
+      code: 'Enter',
+      keyCode: 13,
+      which: 13,
+      bubbles: true,
+      cancelable: true,
+      view: window,
+    }));
+    expect(block.querySelectorAll('.additional-row.collapsed').length).to.equal(0);
+  });
+});


### PR DESCRIPTION
Describe your specific features or fixes

Restores the missing CSS rule causing table rows to not be hidden.

Resolves: [[MWPW-172777](https://jira.corp.adobe.com/browse/MWPW-172777)](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://pricing-table-fix--express-milo--adobecom.aem.page/docs/library/kitchen-sink/pricing-table
https://pricing-table-fix--express-milo--adobecom.aem.page/drafts/echen/ambassadors-copy
 
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/enterprises-2
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/individuals-and-teams
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/individuals-and-teams-premium
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/educators
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/enterprises
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/nonprofits
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/students-premium
https://pricing-table-fix--express-milo--adobecom.aem.page/express/fragments/pricing-table/students

<img width="1085" alt="Screenshot 2025-05-07 at 12 00 40 PM" src="https://github.com/user-attachments/assets/379a447b-3b04-49c0-8444-0a63a2cfe281" />

Test Instructions

Visit the pages above and verify that the expand + button now properly hides the content. Verify that the views on mobile are the same.

