### PR TITLE
Mobile fork null column

### DIFF
--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.css
@@ -15,7 +15,7 @@ main .mobile-gating-text {
     font-weight: 400;
     font-size: var(--mfb-font-size);
 }
-
+main .mobile-fork-button-frictionless .floating-button .mobile-gating-row .mobile-gating-icon-empty,
 main .mobile-gating-text, main .mobile-fork-button-frictionless .floating-button .mobile-gating-row .icon{
     width: 22px;
     height: 22px;

--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -41,11 +41,52 @@ export async function createMultiFunctionButton(block, data, audience) {
   return buttonWrapper;
 }
 
-function collectFloatingButtonData(eligible) {
-  const metadataMap = Array.from(document.head.querySelectorAll('meta')).reduce((acc, meta) => {
+function createMetadataMap() {
+  return Array.from(document.head.querySelectorAll('meta')).reduce((acc, meta) => {
     if (meta?.name && !meta.property) acc[meta.name] = meta.content || '';
     return acc;
   }, {});
+}
+
+function createToolData(metadataMap, index, eligible) {
+  const prefix = `fork-cta-${index}`;
+  console.log(`${prefix}-icon-frictionless`, eligible && metadataMap[`${prefix}-icon-frictionless`])
+  const iconMetadata = (eligible && metadataMap[`${prefix}-icon-frictionless`]) || metadataMap[`${prefix}-icon`];
+  const iconTextMetadata = (eligible && metadataMap[`${prefix}-icon-text-frictionless`]) || metadataMap[`${prefix}-icon-text`];
+  const hrefMetadata = (eligible && metadataMap[`${prefix}-link-frictionless`]) || metadataMap[`${prefix}-link`];
+  const textMetadata = (eligible && metadataMap[`${prefix}-text-frictionless`]) || metadataMap[`${prefix}-text`];
+  const iconElement = !iconMetadata || iconMetadata === 'null'
+    ? createTag('div', { class: 'mobile-gating-icon-empty' })
+    : getIconElementDeprecated(iconMetadata);
+
+  const completeSet = {
+    icon: iconElement,
+    iconText: iconTextMetadata || '',
+    href: hrefMetadata,
+    text: textMetadata,
+  };
+
+  const { href, text, icon, iconText } = completeSet;
+  const aTag = createTag('a', { title: text, href });
+  console.log(completeSet)
+  // Handle mobile-fqa upload special case
+  if (href.toLowerCase().trim() === '#mobile-fqa-upload') {
+    aTag.addEventListener('click', (e) => {
+      e.preventDefault();
+      document.getElementById('mobile-fqa-upload').click();
+    });
+  }
+
+  aTag.textContent = text;
+  return {
+    icon,
+    anchor: aTag,
+    iconText,
+  };
+}
+
+function collectFloatingButtonData(eligible) {
+  const metadataMap = createMetadataMap();
   const getMetadataLocal = (key) => metadataMap[key];
   const data = {
     scrollState: 'withLottie',
@@ -65,43 +106,14 @@ function collectFloatingButtonData(eligible) {
     live: getMetadataLocal('floating-cta-live'),
     forkButtonHeader: getMetadataLocal('fork-button-header'),
   };
-
+ 
   for (let i = 1; i < 3; i += 1) {
-    const prefix = `fork-cta-${i}`;
-    const iconMetadata = (eligible && getMetadataLocal(`${prefix}-icon-frictionless`)) || getMetadataLocal(`${prefix}-icon`);
-    const iconTextMetadata = (eligible && getMetadataLocal(`${prefix}-icon-text-frictionless`)) || getMetadataLocal(`${prefix}-icon-text`);
-    const hrefMetadata = (eligible && getMetadataLocal(`${prefix}-link-frictionless`)) || getMetadataLocal(`${prefix}-link`);
-    const textMetadata = (eligible && getMetadataLocal(`${prefix}-text-frictionless`)) || getMetadataLocal(`${prefix}-text`);
-    if (!iconMetadata) break;
-    const completeSet = {
-      icon: getIconElementDeprecated(iconMetadata),
-      iconText: iconTextMetadata,
-      href: hrefMetadata,
-      text: textMetadata,
-    };
-
-    if (Object.values(completeSet).every((val) => !!val)) {
-      const {
-        href, text, icon, iconText,
-      } = completeSet;
-      const aTag = createTag('a', { title: text, href });
-      if (href.toLowerCase().trim() === '#mobile-fqa-upload') {
-        // mobile-fork-button-frictionless pairs with mobile-fqa
-        // temporary solution before a nicer way for cross-block interactions is found
-        aTag.addEventListener('click', (e) => {
-          e.preventDefault();
-          document.getElementById('mobile-fqa-upload').click();
-        });
-      }
-      aTag.textContent = text;
-      if (getTextWidth(text, 16) > LONG_TEXT_CUTOFF) {
+    const toolData = createToolData(metadataMap, i, eligible);
+    if (toolData) {
+      data.tools.push(toolData);
+      if (getTextWidth(toolData.anchor.textContent, 16) > LONG_TEXT_CUTOFF) {
         data.longText = true;
       }
-      data.tools.push({
-        icon,
-        anchor: aTag,
-        iconText,
-      });
     }
   }
   return data;

--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -96,7 +96,7 @@ function collectFloatingButtonData(eligible) {
     live: getMetadataLocal('floating-cta-live'),
     forkButtonHeader: getMetadataLocal('fork-button-header'),
   };
- 
+
   for (let i = 1; i < 3; i += 1) {
     const toolData = createToolData(metadataMap, i, eligible);
     if (toolData) {

--- a/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
+++ b/express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js
@@ -50,38 +50,28 @@ function createMetadataMap() {
 
 function createToolData(metadataMap, index, eligible) {
   const prefix = `fork-cta-${index}`;
-  console.log(`${prefix}-icon-frictionless`, eligible && metadataMap[`${prefix}-icon-frictionless`])
   const iconMetadata = (eligible && metadataMap[`${prefix}-icon-frictionless`]) || metadataMap[`${prefix}-icon`];
   const iconTextMetadata = (eligible && metadataMap[`${prefix}-icon-text-frictionless`]) || metadataMap[`${prefix}-icon-text`];
-  const hrefMetadata = (eligible && metadataMap[`${prefix}-link-frictionless`]) || metadataMap[`${prefix}-link`];
-  const textMetadata = (eligible && metadataMap[`${prefix}-text-frictionless`]) || metadataMap[`${prefix}-text`];
+  const hrefMetadata = (eligible && metadataMap[`${prefix}-link-frictionless`]) || metadataMap[`${prefix}-link`] || '';
+  const textMetadata = (eligible && metadataMap[`${prefix}-text-frictionless`]) || metadataMap[`${prefix}-text`] || '';
+
   const iconElement = !iconMetadata || iconMetadata === 'null'
     ? createTag('div', { class: 'mobile-gating-icon-empty' })
     : getIconElementDeprecated(iconMetadata);
 
-  const completeSet = {
-    icon: iconElement,
-    iconText: iconTextMetadata || '',
-    href: hrefMetadata,
-    text: textMetadata,
-  };
-
-  const { href, text, icon, iconText } = completeSet;
-  const aTag = createTag('a', { title: text, href });
-  console.log(completeSet)
-  // Handle mobile-fqa upload special case
-  if (href.toLowerCase().trim() === '#mobile-fqa-upload') {
+  const aTag = createTag('a', { title: textMetadata, href: hrefMetadata });
+  if (hrefMetadata.toLowerCase().trim() === '#mobile-fqa-upload') {
     aTag.addEventListener('click', (e) => {
       e.preventDefault();
       document.getElementById('mobile-fqa-upload').click();
     });
   }
+  aTag.textContent = textMetadata;
 
-  aTag.textContent = text;
   return {
-    icon,
+    icon: iconElement,
     anchor: aTag,
-    iconText,
+    iconText: iconTextMetadata || '',
   };
 }
 

--- a/express/code/blocks/mobile-fork-button/mobile-fork-button.css
+++ b/express/code/blocks/mobile-fork-button/mobile-fork-button.css
@@ -19,7 +19,7 @@ main .mobile-gating-text {
     font-weight: 400;
     font-size: var(--mfb-font-size);
 }
-
+main .mobile-fork-button .floating-button .mobile-gating-row .mobile-gating-icon-empty,
 main .mobile-gating-text, main .mobile-fork-button .floating-button .mobile-gating-row .icon{
     width: 22px;
     height: 22px;

--- a/express/code/blocks/mobile-fork-button/mobile-fork-button.js
+++ b/express/code/blocks/mobile-fork-button/mobile-fork-button.js
@@ -21,7 +21,7 @@ function buildAction(entry, buttonType) {
   if (a) {
     a.classList.add(buttonType, 'button', 'mobile-gating-link');
     wrapper.append(entry?.icon || null, text, a);
-  } 
+  }
   return wrapper;
 }
 
@@ -68,16 +68,16 @@ function createToolData(metadataMap, index) {
     ? createTag('div', { class: 'mobile-gating-icon-empty' })
     : getIconElementDeprecated(iconMetadata);
 
-  const aTag = createTag('a', { 
-    title: textMetadata, 
-    href: hrefMetadata 
+  const aTag = createTag('a', {
+    title: textMetadata,
+    href: hrefMetadata,
   });
   aTag.textContent = textMetadata;
 
   return {
     icon: iconElement,
     iconText: iconTextMetadata,
-    anchor: aTag
+    anchor: aTag,
   };
 }
 

--- a/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
+++ b/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
@@ -9,7 +9,7 @@ import { buildAutoBlocks } from '../../../express/code/scripts/utils.js';
 
 const imports = await Promise.all([
   import('../../../express/code/scripts/scripts.js'),
-  import('../../../express/code/blocks/mobile-fork-button/mobile-fork-button.js'),
+  import('../../../express/code/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.js'),
 ]);
 const { default: decorate } = imports[1];
 
@@ -17,7 +17,7 @@ function setDocumentMetadata(includeForkCta2 = true) {
   const metadata = {
     'floating-cta-live': 'Y',
     'show-floating-cta': 'yes',
-    'mobile-floating-cta': 'mobile-fork-button',
+    'mobile-floating-cta': 'mobile-fork-button-frictionless',
     'desktop-floating-cta': 'floating-button',
     'main-cta-link': 'https://www.adobe.com/express/create',
     'main-cta-text': 'Get the full experience in the app.',
@@ -44,7 +44,7 @@ function setDocumentMetadata(includeForkCta2 = true) {
   });
 }
 
-describe('Mobile Fork Button', () => {
+describe('Mobile Fork Button Frictionless', () => {
   beforeEach(async () => {
     window.isTestEnv = true;
     window.hlx = {};

--- a/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
+++ b/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
@@ -2,9 +2,7 @@
 /* eslint-disable no-unused-vars */
 
 import { readFile } from '@web/test-runner-commands';
-import { expect } from '@esm-bundle/chai';
-// ... existing code ...
-
+import { expect } from '@esm-bundle/chai'; 
 import { buildAutoBlocks } from '../../../express/code/scripts/utils.js';
 
 const imports = await Promise.all([

--- a/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
+++ b/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
@@ -63,6 +63,11 @@ describe('Mobile Fork Button Frictionless', () => {
     });
   });
 
+  afterEach(() => {
+    window.placeholders = undefined;
+    document.body.innerHTML = '';
+  });
+
   it('renders button with both fork-cta-1 and fork-cta-2 metadata', async () => {
     setDocumentMetadata(true);
     await buildAutoBlocks();

--- a/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
+++ b/test/blocks/mobile-fork-button-frictionless/mobile-fork-button-frictionless.test.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 
 import { readFile } from '@web/test-runner-commands';
-import { expect } from '@esm-bundle/chai'; 
+import { expect } from '@esm-bundle/chai';
 import { buildAutoBlocks } from '../../../express/code/scripts/utils.js';
 
 const imports = await Promise.all([

--- a/test/blocks/mobile-fork-button-frictionless/mocks/body.html
+++ b/test/blocks/mobile-fork-button-frictionless/mocks/body.html
@@ -1,0 +1,3 @@
+<main>
+  <div class="section"></div>
+</main>

--- a/test/blocks/mobile-fork-button/mobile-fork-button.test.js
+++ b/test/blocks/mobile-fork-button/mobile-fork-button.test.js
@@ -27,8 +27,6 @@ function setDocumentMetadata(includeForkCta2 = true) {
     'fork-cta-1-icon-text': 'Adobe Express',
     'floating-cta-device-and-ram-check': 'no',
     'fallback-text': '((mobile-gating-fallback-text))',
-    'show-floating-cta': 'Yes',
-
   };
 
   if (includeForkCta2) {

--- a/test/blocks/mobile-fork-button/mobile-fork-button.test.js
+++ b/test/blocks/mobile-fork-button/mobile-fork-button.test.js
@@ -1,0 +1,90 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-vars */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+// ... existing code ...
+
+import { buildAutoBlocks } from '../../../express/code/scripts/utils.js';
+
+const imports = await Promise.all([
+  import('../../../express/code/scripts/scripts.js'),
+  import('../../../express/code/blocks/mobile-fork-button/mobile-fork-button.js'),
+]);
+const { default: decorate } = imports[1];
+
+function setDocumentMetadata(includeForkCta2 = true) {
+  const metadata = {
+    'floating-cta-live': 'Y',
+    'show-floating-cta': 'yes',
+    'mobile-floating-cta': 'mobile-fork-button',
+    'desktop-floating-cta': 'floating-button',
+    'main-cta-link': 'https://www.adobe.com/express/create',
+    'main-cta-text': 'Get the full experience in the app.',
+    'fork-cta-1-icon': 'cc-express',
+    'fork-cta-1-link': 'https://www.google.com',
+    'fork-cta-1-text': 'Get Free App',
+    'fork-cta-1-icon-text': 'Adobe Express',
+    'floating-cta-device-and-ram-check': 'no',
+    'fallback-text': '((mobile-gating-fallback-text))',
+    'show-floating-cta': 'Yes',
+
+  };
+
+  if (includeForkCta2) {
+    metadata['fork-cta-2-icon'] = 'cc-express';
+    metadata['fork-cta-2-text'] = 'Free Version';
+    metadata['fork-cta-2-link'] = 'https://www.google.com';
+    metadata['fork-cta-2-icon-text'] = 'Test';
+  }
+
+  Object.entries(metadata).forEach(([name, content]) => {
+    const meta = document.createElement('meta');
+    meta.name = name;
+    meta.content = content;
+    document.head.appendChild(meta);
+  });
+}
+
+describe('Mobile Fork Button', () => {
+  beforeEach(async () => {
+    window.isTestEnv = true;
+    window.hlx = {};
+    window.floatingCta = [
+      {
+        path: 'default',
+        live: 'Y',
+      },
+    ];
+    window.placeholders = { 'see-more': 'See More' };
+    document.head.innerHTML = '';
+    document.body.innerHTML = await readFile({ path: './mocks/body.html' });
+
+    // Mock Android user agent
+    Object.defineProperty(navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (Linux; Android 8.0.0; SM-G955U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Mobile Safari/537.36',
+      configurable: true,
+    });
+  });
+
+  it('renders button with both fork-cta-1 and fork-cta-2 metadata', async () => {
+    setDocumentMetadata(true);
+    await buildAutoBlocks();
+    const b = document.querySelector('.floating-button');
+
+    await decorate(b);
+
+    const blockWrapper = document.querySelector('.floating-button.block');
+    console.log(blockWrapper);
+    const rows = blockWrapper.querySelectorAll('.mobile-gating-row');
+    expect(rows.length).to.equal(2);
+
+    const firstRow = rows[0];
+    expect(firstRow.querySelector('a').textContent).to.equal('Get Free App');
+    expect(firstRow.querySelector('.mobile-gating-text').textContent).to.equal('Adobe Express');
+
+    const secondRow = rows[1];
+    expect(secondRow.querySelector('a').textContent).to.equal('Free Version');
+    expect(secondRow.querySelector('.mobile-gating-text').textContent).to.equal('Test');
+  });
+});

--- a/test/blocks/mobile-fork-button/mobile-fork-button.test.js
+++ b/test/blocks/mobile-fork-button/mobile-fork-button.test.js
@@ -2,9 +2,7 @@
 /* eslint-disable no-unused-vars */
 
 import { readFile } from '@web/test-runner-commands';
-import { expect } from '@esm-bundle/chai';
-// ... existing code ...
-
+import { expect } from '@esm-bundle/chai'; 
 import { buildAutoBlocks } from '../../../express/code/scripts/utils.js';
 
 const imports = await Promise.all([

--- a/test/blocks/mobile-fork-button/mobile-fork-button.test.js
+++ b/test/blocks/mobile-fork-button/mobile-fork-button.test.js
@@ -63,6 +63,11 @@ describe('Mobile Fork Button', () => {
     });
   });
 
+  afterEach(() => {
+    window.placeholders = undefined;
+    document.body.innerHTML = '';
+  });
+
   it('renders button with both fork-cta-1 and fork-cta-2 metadata', async () => {
     setDocumentMetadata(true);
     await buildAutoBlocks();

--- a/test/blocks/mobile-fork-button/mobile-fork-button.test.js
+++ b/test/blocks/mobile-fork-button/mobile-fork-button.test.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-vars */
 
 import { readFile } from '@web/test-runner-commands';
-import { expect } from '@esm-bundle/chai'; 
+import { expect } from '@esm-bundle/chai';
 import { buildAutoBlocks } from '../../../express/code/scripts/utils.js';
 
 const imports = await Promise.all([

--- a/test/blocks/mobile-fork-button/mocks/body.html
+++ b/test/blocks/mobile-fork-button/mocks/body.html
@@ -1,0 +1,3 @@
+<main>
+  <div class="section"></div>
+</main>


### PR DESCRIPTION
Describe your specific features or fixes

Allows the mobile fork button + frictionless version to have empty rows for `fork-cta-<x>-icon` and `fork-cta-<x>-icon-text`

https://main--express-milo--adobecom.aem.page/drafts/echen/mobile-gating-cta-blank

Resolves: https://jira.corp.adobe.com/browse/MWPW-172863

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before:

- After:  https://mobile-fork-null-column--express-milo--adobecom.hlx.page/drafts/echen/mobile-gating-cta-blank
- Control: https://mobile-fork-null-column--express-milo--adobecom.aem.page/docs/library/kitchen-sink/mobile-gating-cta
<img width="576" alt="Screenshot 2025-05-12 at 10 22 25 AM" src="https://github.com/user-attachments/assets/985c9b59-2f53-477d-b48d-b5127b5bd824" />
<img width="479" alt="Screenshot 2025-05-12 at 10 22 30 AM" src="https://github.com/user-attachments/assets/2492d40d-9f18-45ac-8e8d-08fee61c9524" />
<img width="623" alt="Screenshot 2025-05-12 at 10 27 26 AM" src="https://github.com/user-attachments/assets/49deb472-70c8-4bd7-b427-8d532112ae4f" />

Test Instructions:
Visit the page above and change the viewport to emulate an android. Verify that the mobile fork button appears and matches the screenshot. Verify that the control link still works normally.

