### PR TITLE
MWPW-171884-MWPW-173622: change invalid aria-role to role

### DIFF
--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -104,7 +104,7 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
     step: [],
   };
 
-  const numbers = createTag('div', { class: 'tip-numbers', 'aria-role': 'tablist' });
+  const numbers = createTag('div', { class: 'tip-numbers', role: 'tablist' });
   block.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });
   block.append(tips);
@@ -141,7 +141,7 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
       class: `tip-number tip-${i + 1}`,
       tabindex: '0',
       title: `${i + 1}`,
-      'aria-role': 'tab',
+      role: 'tab',
     });
     number.innerHTML = `<span>${i + 1}</span>`;
     number.setAttribute('data-tip-index', i + 1);

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -104,7 +104,7 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
     step: [],
   };
 
-  const numbers = createTag('div', { class: 'tip-numbers', role: 'tablist' });
+  const numbers = createTag('ul', { class: 'tip-numbers', role: 'tablist' });
   block.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });
   block.append(tips);
@@ -137,7 +137,7 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
       },
     });
 
-    const number = createTag('div', {
+    const number = createTag('li', {
       class: `tip-number tip-${i + 1}`,
       tabindex: '0',
       title: `${i + 1}`,


### PR DESCRIPTION
- Change the attribute from 'aria-role' to 'role'
- change divs to ul > li

NOTE: We are not focusing here on keyboard access, but still seems off as the arrow left and right are not compliant. Also, tab should be able to select the items as Enter does.

Resolves: [MWPW-171884](https://jira.corp.adobe.com/browse/MWPW-171884), [MWPW-171884](https://jira.corp.adobe.com/browse/MWPW-173622)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/create/poster
- After: https://mwpw-171817--express-milo--adobecom.aem.page/express/create/poster

For /es locale:
https://main--express-milo--adobecom.aem.page/es/express/create/poster
