### PR TITLE
[MWPW-171954][Sev-1] Frictionless QA 320px Legal Text

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -64,6 +64,8 @@
 
 .frictionless-quick-action .fqa-container > div:nth-child(2) {
     margin-top: 26px;
+    width: 100%;
+    max-width: 638px;
 }
 
 .frictionless-quick-action video,
@@ -76,7 +78,6 @@
     padding: 24px 0;
     border-radius: 20px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
-    width: 630px;
     height: 284px;
 }
 

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -205,9 +205,8 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     }
 }
 
-@media (max-width: 320px) {
-    .frictionless-quick-action .fqa-container > div:nth-child(2) > p:last-of-type{
-        width: 90vw;
-        margin: auto;
-    }
+.frictionless-quick-action .fqa-container > div:nth-child(2) > p:last-of-type{
+    max-width: 90vw;
+    margin-left: auto;
+    margin-right: auto;
 }

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -206,8 +206,8 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
 }
 
 @media (max-width: 320px) {
-    .frictionless-quick-action .fqa-container p {
-        width: 300px;
+    .frictionless-quick-action .fqa-container > div:nth-child(2) > p:last-of-type{
+        width: 90vw;
         margin: auto;
     }
 }

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -82,6 +82,7 @@
 }
 
 .frictionless-quick-action .dropzone-bg {
+    display: none;
     position: absolute;
     width: 100%;
     height: 100%;
@@ -198,6 +199,12 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     display: flex;
     align-items: center;
     cursor: pointer;
+}
+
+@media (min-width: 768px) {
+    .frictionless-quick-action .dropzone-bg{
+        display: block;
+    }
 }
 
 @media (min-width: 1200) {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -204,3 +204,10 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
         height: 1000px;
     }
 }
+
+@media (max-width: 320px) {
+    .frictionless-quick-action .fqa-container p {
+        width: 300px;
+        margin: auto;
+    }
+}


### PR DESCRIPTION
Describe your specific features or fixes

Adds a max 320px breakpoint for the free plan text of this block. Allows the full legal text to be shown at this low resolution.

Resolves: https://jira.corp.adobe.com/browse/MWPW-171954
https://jira.corp.adobe.com/browse/MWPW-173631

Test Instructions:

Visit the url below and open the inspector. do not emulate any devices, but shrink the responsive screen down to 320px or below. Verify that the legal text at the bottom is fully visible.

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://frictionless-qa-zoom--express-milo--adobecom.hlx.page/express/feature/image/remove-background
- 
<img width="311" alt="Screenshot 2025-05-19 at 1 32 40 PM" src="https://github.com/user-attachments/assets/c1bab892-2138-476d-87a9-4886001f3793" />

