### PR TITLE
MWPW-172189: enlarges icon share template X

### DIFF
--- a/express/code/blocks/holiday-blade/holiday-blade.css
+++ b/express/code/blocks/holiday-blade/holiday-blade.css
@@ -371,8 +371,8 @@
 .holiday-blade-inner-content .template .button-container .media-wrapper .icon-share-arrow {
     cursor: pointer;
     pointer-events: auto;
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
     padding: 4px;
     background-color: white;
     overflow: visible;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2314,8 +2314,8 @@ main .template-x.horizontal > .template-x.horizontal.tabbed > .template-title {
 .template-x .template .button-container .media-wrapper .icon-share-arrow {
   cursor: pointer;
   pointer-events: auto;
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   padding: 4px;
   background-color: white;
   overflow: visible;


### PR DESCRIPTION
Share icon was too small per accessibility.
- increase share icon size to be 24px square

Resolves: [MWPW-172189](https://jira.corp.adobe.com/browse/MWPW-172189)

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/feature/image/editor
- After: https://MWPW-172189--express-milo--adobecom.aem.page/express/feature/image/editor

Testing instructions: 
- visit the link
- hover over the template thumbnails
- right click and inspect the element 
- on the styles tab, activate the :hov subsection and select :focus to keep the element visible
- select the share icon svg
- width and height was changed to 16px, and overall dimensions is 24px
