### PR TITLE
Semantic quote block

### DIFF
--- a/express/code/blocks/quotes/quotes.css
+++ b/express/code/blocks/quotes/quotes.css
@@ -143,7 +143,7 @@
 .quotes.singular .quote-comment p {
   margin: 0;
   font-size: 22px;
-  font-weight: 800;
+  font-weight: var(--heading-font-weight);
   text-align: left;
   line-height: initial;
 }

--- a/express/code/blocks/quotes/quotes.css
+++ b/express/code/blocks/quotes/quotes.css
@@ -837,12 +837,12 @@ main .quotes.carousel .ratings button.selected .icon.icon-star {
 }
 
 
-.quotes .quote .content {
+.quotes .quote blockquote.content {
   text-align: center;
   margin: 0;
 }
 
-.quotes .quote .content .inner-content {
+.quotes .quote blockquote.content .inner-content {
   text-align: left;
   margin: 0;
   line-height: 20px;

--- a/express/code/blocks/quotes/quotes.css
+++ b/express/code/blocks/quotes/quotes.css
@@ -835,3 +835,16 @@ main .quotes.carousel .ratings button.selected .icon.icon-star {
     margin-left: 40px;
   }
 }
+
+
+.quotes .quote .content {
+  text-align: center;
+  margin: 0;
+}
+
+.quotes .quote .content .inner-content {
+  text-align: left;
+  margin: 0;
+  line-height: 20px;
+  font-size: var(--body-font-size-m);
+}

--- a/express/code/blocks/quotes/quotes.css
+++ b/express/code/blocks/quotes/quotes.css
@@ -140,6 +140,14 @@
   padding-bottom: 0;
 }
 
+.quotes.singular .quote-comment p {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  text-align: left;
+  line-height: initial;
+}
+
 .quotes .quote {
   box-sizing: border-box;
   border-radius: 20px;

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -31,12 +31,12 @@ function pickRandomFromArray(arr) {
   return arr[Math.floor(arr.length * Math.random())];
 }
 
-function createQuoteContent($card) {
-  const $blockquote = createTag('blockquote', { class: 'content' });
+function createQuoteContent(textContent, addContentClass = false) {
+  const $blockquote = createTag('blockquote', { class: addContentClass ? 'content' : '' });
   const $p = createTag('p', { class: 'inner-content' });
-  $p.textContent = $card.firstElementChild.textContent;
+  $p.textContent = textContent;
   $blockquote.appendChild($p);
-  $card.firstElementChild.replaceWith($blockquote);
+  return $blockquote;
 }
 
 async function createQuotesRatings({
@@ -309,12 +309,9 @@ export default async function decorate($block) {
     const $quoteComment = createTag('div', { class: 'quote-comment' });
     $quoteDetails.append($quoteComment);
 
-    const $review = $quoteSelected.children[0];
-    const $blockquote = createTag('blockquote');
-    const $p = createTag('p');
-    $p.textContent = $review.textContent;
-    $blockquote.appendChild($p);
-    $quoteComment.append($blockquote);
+    $quoteComment.append(createQuoteContent(
+      $quoteSelected.firstElementChild.textContent,
+    ));
 
     const authorDescription = $quoteSelected.children[1].textContent;
 
@@ -403,8 +400,8 @@ export default async function decorate($block) {
         $author.appendChild($authorContent);
       }
 
-      createQuoteContent($card);
-
+      const $blockquote = createQuoteContent($card.firstElementChild.textContent, true);
+      $card.firstElementChild.replaceWith($blockquote);
       // Move author before content
       if ($card.children.length > 1) {
         $card.insertBefore($card.children[1], $card.firstElementChild);
@@ -465,7 +462,8 @@ export default async function decorate($block) {
         $author.appendChild($authorContent);
       }
 
-      createQuoteContent($card);
+      const $blockquote = createQuoteContent($card.firstElementChild.textContent, true);
+      $card.firstElementChild.replaceWith($blockquote);
     });
   }
 }

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -302,8 +302,13 @@ export default async function decorate($block) {
     $quoteDetails.append($quoteComment);
 
     const $review = $quoteSelected.children[0];
-
-    $quoteComment.append($review.textContent);
+    const $blockquote = createTag('blockquote');
+    const $p = createTag('p');
+    const $q = createTag('q');
+    $q.textContent = $review.textContent;
+    $p.appendChild($q);
+    $blockquote.appendChild($p);
+    $quoteComment.append($blockquote);
 
     const authorDescription = $quoteSelected.children[1].textContent;
 

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -303,10 +303,8 @@ export default async function decorate($block) {
 
     const $review = $quoteSelected.children[0];
     const $blockquote = createTag('blockquote');
-    const $p = createTag('p');
-    const $q = createTag('q');
-    $q.textContent = $review.textContent;
-    $p.appendChild($q);
+    const $p = createTag('p'); 
+    $p.textContent = $review.textContent;
     $blockquote.appendChild($p);
     $quoteComment.append($blockquote);
 

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -392,11 +392,7 @@ export default async function decorate($block) {
         $author.appendChild($authorContent);
       }
 
-      const $blockquote = createTag('blockquote', { class: 'content' });
-      const $p = createTag('p', { class: 'inner-content' });
-      $p.textContent = $card.firstElementChild.textContent;
-      $blockquote.appendChild($p);
-      $card.firstElementChild.replaceWith($blockquote);
+      createQuoteContent($card);
 
       // Move author before content
       if ($card.children.length > 1) {
@@ -458,11 +454,15 @@ export default async function decorate($block) {
         $author.appendChild($authorContent);
       }
 
-      const $blockquote = createTag('blockquote', { class: 'content' });
-      const $p = createTag('p', { class: 'inner-content' });
-      $p.textContent = $card.firstElementChild.textContent;
-      $blockquote.appendChild($p);
-      $card.firstElementChild.replaceWith($blockquote);
+      createQuoteContent($card);
     });
   }
+}
+
+function createQuoteContent($card) {
+  const $blockquote = createTag('blockquote', { class: 'content' });
+  const $p = createTag('p', { class: 'inner-content' });
+  $p.textContent = $card.firstElementChild.textContent;
+  $blockquote.appendChild($p);
+  $card.firstElementChild.replaceWith($blockquote);
 }

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -31,6 +31,14 @@ function pickRandomFromArray(arr) {
   return arr[Math.floor(arr.length * Math.random())];
 }
 
+function createQuoteContent($card) {
+  const $blockquote = createTag('blockquote', { class: 'content' });
+  const $p = createTag('p', { class: 'inner-content' });
+  $p.textContent = $card.firstElementChild.textContent;
+  $blockquote.appendChild($p);
+  $card.firstElementChild.replaceWith($blockquote);
+}
+
 async function createQuotesRatings({
   sheet,
   isCarouselVariant = false,
@@ -303,7 +311,7 @@ export default async function decorate($block) {
 
     const $review = $quoteSelected.children[0];
     const $blockquote = createTag('blockquote');
-    const $p = createTag('p'); 
+    const $p = createTag('p');
     $p.textContent = $review.textContent;
     $blockquote.appendChild($p);
     $quoteComment.append($blockquote);
@@ -460,12 +468,4 @@ export default async function decorate($block) {
       createQuoteContent($card);
     });
   }
-}
-
-function createQuoteContent($card) {
-  const $blockquote = createTag('blockquote', { class: 'content' });
-  const $p = createTag('p', { class: 'inner-content' });
-  $p.textContent = $card.firstElementChild.textContent;
-  $blockquote.appendChild($p);
-  $card.firstElementChild.replaceWith($blockquote);
 }

--- a/express/code/blocks/quotes/quotes.js
+++ b/express/code/blocks/quotes/quotes.js
@@ -391,7 +391,12 @@ export default async function decorate($block) {
         $authorContent.appendChild($authorSummary);
         $author.appendChild($authorContent);
       }
-      $card.firstElementChild.classList.add('content');
+
+      const $blockquote = createTag('blockquote', { class: 'content' });
+      const $p = createTag('p', { class: 'inner-content' });
+      $p.textContent = $card.firstElementChild.textContent;
+      $blockquote.appendChild($p);
+      $card.firstElementChild.replaceWith($blockquote);
 
       // Move author before content
       if ($card.children.length > 1) {
@@ -452,7 +457,12 @@ export default async function decorate($block) {
         // Append the author content container to author
         $author.appendChild($authorContent);
       }
-      $card.firstElementChild.classList.add('content');
+
+      const $blockquote = createTag('blockquote', { class: 'content' });
+      const $p = createTag('p', { class: 'inner-content' });
+      $p.textContent = $card.firstElementChild.textContent;
+      $blockquote.appendChild($p);
+      $card.firstElementChild.replaceWith($blockquote);
     });
   }
 }


### PR DESCRIPTION
Describe your specific features or fixes

Implements semantic HTML outputs for the quote block. Elements now use `<blockquote/>` instead of `<div/>`

Resolves: https://jira.corp.adobe.com/browse/MWPW-172622

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://semantic-quote-block--express-milo--adobecom.aem.page/docs/library/kitchen-sink/quotes
- https://semantic-quote-block--express-milo--adobecom.aem.page/express/create/logo
--


</body></html></div>

<img width="1258" alt="Screenshot 2025-05-14 at 1 21 00 PM" src="https://github.com/user-attachments/assets/950c9769-4f49-459b-97c9-b7c6e18985e0" />
<img width="1219" alt="Screenshot 2025-05-14 at 1 21 03 PM" src="https://github.com/user-attachments/assets/becc267b-0f1d-4650-9f54-4db3fc95919d" />
<img width="1219" alt="Screenshot 2025-05-14 at 1 21 07 PM" src="https://github.com/user-attachments/assets/154c83a7-043e-4c2c-a4e6-9b026035e64f" />
<img width="1255" alt="Screenshot 2025-05-14 at 1 21 11 PM" src="https://github.com/user-attachments/assets/f86fcb94-d55c-44dd-8bc1-cdc1dd0e9265" />

