### PR TITLE
[MWPW-172869] Content Toggle Reflow Fix

### DIFF
--- a/express/code/blocks/content-toggle/content-toggle.css
+++ b/express/code/blocks/content-toggle/content-toggle.css
@@ -12,10 +12,12 @@ main .section .content-toggle-wrapper {
     margin: 0 auto;
     padding: 0 13px;
     max-width: max-content;
+    overflow-x: scroll;
 }
 
 main .content-toggle {
     position: relative;
+    width: fit-content;
     display: flex;
     justify-content: center;
     background-color: #EDEDED;

--- a/express/code/blocks/content-toggle/content-toggle.js
+++ b/express/code/blocks/content-toggle/content-toggle.js
@@ -81,6 +81,22 @@ function initButton($block, $sections, index) {
       setActiveButton(index);
     }
 
+    // Add focus event listener to scroll button into view
+    $buttons[index].addEventListener('focus', () => {
+      const $wrapper = $block.closest('.content-toggle-wrapper');
+      const buttonRect = $buttons[index].getBoundingClientRect();
+      const wrapperRect = $wrapper.getBoundingClientRect();
+      
+      // Calculate if button is outside wrapper's visible area
+      if (buttonRect.left < wrapperRect.left) {
+        // Button is too far left, scroll it into view
+        $wrapper.scrollLeft += buttonRect.left - wrapperRect.left - 10; // 10px padding
+      } else if (buttonRect.right > wrapperRect.right) {
+        // Button is too far right, scroll it into view
+        $wrapper.scrollLeft += buttonRect.right - wrapperRect.right + 10; // 10px padding
+      }
+    });
+
     $buttons[index].addEventListener('click', () => {
       const $activeButton = $block.querySelector('button.active');
       const blockPosition = $block.getBoundingClientRect().top;


### PR DESCRIPTION
Describe your specific features or fixes

Fixes the content toggle block at low resolutions. When the user focuses a new tab, the screen automatically scrolls to the button to keep the control inside the screen.

Resolves: https://jira.corp.adobe.com/browse/MWPW-172869

Test Instructions:

Zoom to 200% and try using the nav bar. Verify that you can focus the different elements to bring them to the center of the screen and that they change the section content accordingly.

Test URLs:
- Pre Migration Link: https://adobe.com/express/
- Before: https://main--express-milo--adobecom.aem.page/express/
- After: https://content-toggle-overflow-fix--express-milo--adobecom.aem.page/de/education/express/
