### PR TITLE
[MWPW-173637] - Shrink Assets Too Large

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -43,6 +43,7 @@
     width: 100%;
     margin: auto;
     transition: opacity 0.2s;
+    height: 667px;
 }
 
 .frictionless-quick-action-mobile video,
@@ -63,13 +64,11 @@
     height: var(--animation-h);
 }
 
-.frictionless-quick-action-mobile .animation-container video {
-    width: 100%;
-    height: 100%;
-}
-
+.frictionless-quick-action-mobile .animation-container video,
 .frictionless-quick-action-mobile .animation-container img {
-  width: 100%;
+    width: 100%;
+    max-height: 100%;
+    object-fit: contain;
 }
 
 .frictionless-quick-action-mobile .animation-container.hide {
@@ -174,10 +173,6 @@
 
 .frictionless-quick-action-mobile .free-plan-widget img.icon.icon-checkmark {
     background-color: #f06dad;
-}
-
-.frictionless-quick-action-mobile .quick-action-container {
-    height: 667px;
 }
 
 .frictionless-quick-action-mobile .quick-action-container > * {

--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -1,5 +1,6 @@
 .frictionless-quick-action-mobile {
     --animation-h: 260px;
+    --quick-action-container-h: 667px;
 }
 
 .section .frictionless-quick-action-mobile {
@@ -43,7 +44,7 @@
     width: 100%;
     margin: auto;
     transition: opacity 0.2s;
-    height: 667px;
+    height: var(--quick-action-container-h);
 }
 
 .frictionless-quick-action-mobile video,


### PR DESCRIPTION
Added max-height and object-fit contain to mobile-frictionless animation to avoid layout shifting or content overflowing.

Resolves: https://jira.corp.adobe.com/browse/MWPW-173637

Test URLs:
- Before: https://stage--express-milo--adobecom.aem.page/drafts/yge/en/feature/image/rb-mobile/ai/remove-background?martech=off
- After: https://mobile-frictionless-img-height--express-milo--adobecom.aem.page/drafts/yge/en/feature/image/rb-mobile/ai/remove-background?martech=off

How to test:
- Open the page using **Mobile Android**
- See that the image would overlap with below text in stage, but would shrink in the branch link
- All currently deployed pages should not be affected at all. This PR is to handle future content where img/video could be too tall

Page to check for regression:
https://mobile-frictionless-img-height--express-milo--adobecom.aem.live/express/feature/image/remove-background?martech=off