### PR TITLE
[MWPW-172781] Fullscreen Marquee Free Plan Widget Update

### DIFF
--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -37,10 +37,6 @@
   text-align: left;
 }
 
-.fullscreen-marquee .fullscreen-marquee-heading .button-container {
-  display: none;
-}
-
 .fullscreen-marquee-heading h1.budoux {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Enables the free plan widget on low resolution desktops for the fullscreen marquee

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-172781

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://fullscreen-marquee-free-plan--express-milo--adobecom.aem.page/express/create/poster

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
Visit the test url and either zoom in 200% or change the screen size to 320px responsive. verify that the free plan button still shows up
---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://fullscreen-marquee-free-plan--express-milo--adobecom.aem.page/express/create/**
https://fullscreen-marquee-free-plan--express-milo--adobecom.hlx.live/it/express/create/wallpaper
https://fullscreen-marquee-free-plan--express-milo--adobecom.hlx.live/express/create/banner/vertical
--


</body></html></div>


</body></html></div>
---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
