### PR TITLE
[MWPW-173484] View All Button Aria

### DIFF
--- a/express/code/blocks/cta-carousel/cta-carousel.js
+++ b/express/code/blocks/cta-carousel/cta-carousel.js
@@ -41,7 +41,7 @@ export function decorateHeading(block, payload) {
       headingTextWrapper.append(p);
     });
   }
-  if (payload.viewAllLink.href !== '') {
+  if (payload?.viewAllLink !== null) {
     const viewAllButton = payload.viewAllLink;
     viewAllButton.className = 'cta-carousel-link';
     headingSection.append(viewAllButton);

--- a/express/code/blocks/cta-carousel/cta-carousel.js
+++ b/express/code/blocks/cta-carousel/cta-carousel.js
@@ -229,7 +229,7 @@ function constructPayload(block) {
   const payload = {
     heading: headingDiv.querySelector('h2, h3, h4, h5, h6')?.textContent?.trim(),
     subHeadings: headingDiv.querySelectorAll('p:not(.button-container)'),
-    viewAllLink: headingDiv.querySelector('a.button') ,
+    viewAllLink: headingDiv.querySelector('a.button'),
     actions: [],
   };
 

--- a/express/code/blocks/cta-carousel/cta-carousel.js
+++ b/express/code/blocks/cta-carousel/cta-carousel.js
@@ -225,8 +225,6 @@ function constructPayload(block) {
   const rows = Array.from(block.children);
   block.innerHTML = '';
   const headingDiv = rows.shift();
-  console.log(headingDiv.querySelector('a.button'))
-  console.log(headingDiv.querySelector('a.button')?.textContent)
 
   const payload = {
     heading: headingDiv.querySelector('h2, h3, h4, h5, h6')?.textContent?.trim(),

--- a/express/code/blocks/cta-carousel/cta-carousel.js
+++ b/express/code/blocks/cta-carousel/cta-carousel.js
@@ -41,13 +41,9 @@ export function decorateHeading(block, payload) {
       headingTextWrapper.append(p);
     });
   }
-
   if (payload.viewAllLink.href !== '') {
-    const viewAllButton = createTag('a', {
-      class: 'cta-carousel-link',
-      href: payload.viewAllLink.href,
-    });
-    viewAllButton.textContent = payload.viewAllLink.text;
+    const viewAllButton = payload.viewAllLink;
+    viewAllButton.className = 'cta-carousel-link';
     headingSection.append(viewAllButton);
   }
 
@@ -229,14 +225,13 @@ function constructPayload(block) {
   const rows = Array.from(block.children);
   block.innerHTML = '';
   const headingDiv = rows.shift();
+  console.log(headingDiv.querySelector('a.button'))
+  console.log(headingDiv.querySelector('a.button')?.textContent)
 
   const payload = {
     heading: headingDiv.querySelector('h2, h3, h4, h5, h6')?.textContent?.trim(),
     subHeadings: headingDiv.querySelectorAll('p:not(.button-container)'),
-    viewAllLink: {
-      text: headingDiv.querySelector('a.button')?.textContent?.trim(),
-      href: headingDiv.querySelector('a.button')?.href,
-    },
+    viewAllLink: headingDiv.querySelector('a.button') ,
     actions: [],
   };
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

This PR takes advantage of Milo's pipe operator capability that automatically adds the aria label to the button and directly constructs the view all link from the authored button.

---

## Jira Ticket

Resolves: [MWPW-173484](https://jira.corp.adobe.com/browse/MWPW-173484)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://mwpw-173484-view-all--express-milo--adobecom.aem.page/drafts/echen/cta-carousel-alt

---

## Verification Steps

Please include:
- View the page and check the aria label of the view all link. Verify that it is present and that the link leads you to a sparkpost domain. 
- Some pages do not have a view all link authored. Be sure that the block does not crash in these cases.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://mwpw-173484-view-all--express-milo--adobecom.hlx.page/express/print 
- https://mwpw-173484-view-all--express-milo--adobecom.hlx.page/express/feature/image/convert
- https://mwpw-173484-view-all--express-milo--adobecom.hlx.page/express/feature/video/convert
- https://mwpw-173484-view-all--express-milo--adobecom.hlx.page/express/feature/quick-actions

---

## Additional Notes

<img width="1007" alt="Screenshot 2025-05-19 at 3 03 25 PM" src="https://github.com/user-attachments/assets/99d1fa0f-f685-4991-b61e-a797ea581a3d" />

(If applicable) Add context, related PRs, or known issues here.
