### PR TITLE
[MWPW-173736] Fix undefined templates params

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -468,10 +468,10 @@ function renderHoverWrapper(template) {
     cta = renderPrintCTA(template);
     ctaLink = renderPrintCTALink(template);
   } else {
-    mv = `?mv=${props.mv}` || '';
-    sdid = `&sdid=${props.sdid}` || '';
-    source = `&source=${props.source}` || '';
-    action = `&action=${props.action}` || '';
+    mv = props.mv ? `?mv=${props.mv}` : '';
+    sdid = props.sdid ? `&sdid=${props.sdid}` : '';
+    source = props.source ? `&source=${props.source}` : '';
+    action = props.action ? `&action=${props.action}` : '';
     cta = renderCTA(template.customLinks.branchUrl);
     ctaLink = renderCTALink(template.customLinks.branchUrl, template);
   }

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -176,7 +176,7 @@ function renderShareWrapper(templateInfo) {
 const buildiFrameContent = (template) => {
   const { branchUrl } = template.customLinks;
   const taskID = props?.taskid;
-  const zazzleUrl = props.zazzleurl;
+  const zazzleUrl = props?.zazzleurl;
   const { lang } = document.documentElement;
   const iFrame = createTag('iframe', {
     src: `${zazzleUrl}?TD=${template.id}&taskID=${taskID}&shortcode=${branchUrl.split('/').pop()}&lang=${lang}`,
@@ -468,10 +468,10 @@ function renderHoverWrapper(template) {
     cta = renderPrintCTA(template);
     ctaLink = renderPrintCTALink(template);
   } else {
-    mv = props.mv ? `?mv=${props.mv}` : '';
-    sdid = props.sdid ? `&sdid=${props.sdid}` : '';
-    source = props.source ? `&source=${props.source}` : '';
-    action = props.action ? `&action=${props.action}` : '';
+    mv = props?.mv ? `?mv=${props.mv}` : '';
+    sdid = props?.sdid ? `&sdid=${props.sdid}` : '';
+    source = props?.source ? `&source=${props.source}` : '';
+    action = props?.action ? `&action=${props.action}` : '';
     cta = renderCTA(template.customLinks.branchUrl);
     ctaLink = renderCTALink(template.customLinks.branchUrl, template);
   }


### PR DESCRIPTION
## Summary

Fixed issues where undefined params getting appended to Templates' CTAs.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-173736

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/templates/flyer |
| **After**   | https://template-undefined-params--express-milo--adobecom.aem.page/express/templates/flyer?martech=off |

---

## Verification Steps

Please include:
- Hover on a template, and inspect its "Edit this template" CTA
- You should see lots of undefined params in stage, but fixed in branch links

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://template-undefined-params--express-milo--adobecom.aem.live/express/print?martech=off

---

## Additional Notes

There should be no visual/functional changes on any pages with templates
