### PR TITLE
[MWPW-173189] H3 Header Support For Cards

### DIFF
--- a/express/code/blocks/cards/cards.css
+++ b/express/code/blocks/cards/cards.css
@@ -108,6 +108,7 @@ main .section .cards.large .card .card-content {
   padding: 32px 32px 8px 32px;
 }
 
+main .section .cards.large .card .card-content h3,
 main .section .cards.large .card .card-content h2 {
   text-align: left;
   font-size: 1.375rem;
@@ -156,7 +157,8 @@ main .section .cards.large .card .card-content li {
   main .section .cards .card .card-content {
     padding: 16px 16px 8px 16px;
   }
-
+  
+  main .section .cards .card .card-content h3,
   main .section .cards .card .card-content h2 {
     text-align: center;
     font-size: 1.25rem;


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Enables support for h3 headers alongside h2 headers for the `card` block

---

## Jira Ticket

Resolves:  [MWPW-173189](https://jira.corp.adobe.com/browse/MWPW-173189)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/create/poster |
| **After**   | https://card-headings-fix--express-milo--adobecom.aem.page/drafts/echen/poster-copy |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page and check the card headings. We expect them to be h3 and look similar to the source page. This change requires an authoring change, so it should only affect this page currently.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://card-headings-fix--express-milo--adobecom.aem.page/express/create/poster

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.


