### PR TITLE
Turn off Browse API Calls on Template Search Pages

### DIFF
--- a/express/code/scripts/utils/browse-api-controller.js
+++ b/express/code/scripts/utils/browse-api-controller.js
@@ -33,6 +33,10 @@ export default async function getData() {
     .map((s) => s && String(s[0]).toUpperCase() + String(s).slice(1))
     .reverse()
     .join(' ');
+  if (textQuery === 'Search') {
+    // turn off for search pages
+    return null;
+  }
   const data = {
     experienceId,
     querySuggestion: {


### PR DESCRIPTION
## Summary

Browse API team wants us to reduce the number of requests coming from us, and on Search pages, the API would return empty results anyway, so adding an early termination to reduce loads.

---

## Jira Ticket

Resolves: Waiting for tickets

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/templates/search?tasks=&tasksx=&phformat=2:3&topics=happy%20cats&q=happy%20cats |
| **After**   | https://no-browse-on-search-pages--express-milo--adobecom.aem.page/express/templates/search?tasks=&tasksx=&phformat=2:3&topics=happy%20cats&q=happy%20cats?martech=off |

---

## Verification Steps
- Go to the page, open the network tab and filter by `ax-uss-api-v2`
- Reload the page
- On stage, there should be 1 call. On the dev link, there should be no such call.

---

## Additional Notes
Our dev branch links are not whitelisted by the API, so we can't easily check for regression until PROD. But hopefully this PR is trivial enough and can be easily rolled back.
