### PR TITLE
[MWPW-172050] How To Carousel States

### DIFF
--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.css
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.css
@@ -99,6 +99,7 @@
 }
 
 .how-to-steps-carousel .tip-number {
+  border: none;
   width: 34px;
   min-width: 34px;
   height: 34px;

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -56,8 +56,6 @@ function activate(block, target) {
       item.setAttribute('aria-selected', 'false');
     }
   });
-
-  console.log( block.querySelectorAll('.tip'))
   // get index of the target
   const i = parseInt(target.getAttribute('data-tip-index'), 10);
   // activate corresponding number and tip

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -65,8 +65,6 @@ function activate(block, target) {
       elem.setAttribute('aria-selected', 'true');
     }
   });
-
-
 }
 
 function initRotation(howToWindow, howToDocument) {

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -108,7 +108,7 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
     step: [],
   };
 
-  const numbers = createTag('nav', { class: 'tip-numbers'});
+  const numbers = createTag('nav', { class: 'tip-numbers' });
   numbers.setAttribute('role', 'tablist');
   block.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -52,16 +52,23 @@ function activate(block, target) {
   // de-activate all
   block.querySelectorAll('.tip, .tip-number').forEach((item) => {
     item.classList.remove('active');
-    item.setAttribute('aria-selected', 'false');
+    if (item.tagName === 'BUTTON') {
+      item.setAttribute('aria-selected', 'false');
+    }
   });
 
+  console.log( block.querySelectorAll('.tip'))
   // get index of the target
   const i = parseInt(target.getAttribute('data-tip-index'), 10);
   // activate corresponding number and tip
   block.querySelectorAll(`.tip-${i}`).forEach((elem) => {
     elem.classList.add('active');
-    elem.setAttribute('aria-selected', 'true');
+    if (elem.tagName === 'BUTTON') {
+      elem.setAttribute('aria-selected', 'true');
+    }
   });
+
+
 }
 
 function initRotation(howToWindow, howToDocument) {

--- a/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
+++ b/express/code/blocks/how-to-steps-carousel/how-to-steps-carousel.js
@@ -52,12 +52,16 @@ function activate(block, target) {
   // de-activate all
   block.querySelectorAll('.tip, .tip-number').forEach((item) => {
     item.classList.remove('active');
+    item.setAttribute('aria-selected', 'false');
   });
 
   // get index of the target
   const i = parseInt(target.getAttribute('data-tip-index'), 10);
   // activate corresponding number and tip
-  block.querySelectorAll(`.tip-${i}`).forEach((elem) => elem.classList.add('active'));
+  block.querySelectorAll(`.tip-${i}`).forEach((elem) => {
+    elem.classList.add('active');
+    elem.setAttribute('aria-selected', 'true');
+  });
 }
 
 function initRotation(howToWindow, howToDocument) {
@@ -104,7 +108,8 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
     step: [],
   };
 
-  const numbers = createTag('div', { class: 'tip-numbers', 'aria-role': 'tablist' });
+  const numbers = createTag('nav', { class: 'tip-numbers'});
+  numbers.setAttribute('role', 'tablist');
   block.prepend(numbers);
   const tips = createTag('div', { class: 'tips' });
   block.append(tips);
@@ -137,12 +142,12 @@ function buildHowToStepsCarousel(section, block, howToDocument, rows, howToWindo
       },
     });
 
-    const number = createTag('div', {
+    const number = createTag('button', {
       class: `tip-number tip-${i + 1}`,
       tabindex: '0',
       title: `${i + 1}`,
-      'aria-role': 'tab',
     });
+    number.setAttribute('role', 'tab');
     number.innerHTML = `<span>${i + 1}</span>`;
     number.setAttribute('data-tip-index', i + 1);
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.
Updates the how to carousel to use semantic HTML + aria labels for screen readers.

Main carousel container is now a nav, tab buttons are now formal buttons.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-172050

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://how-to-carousel-states--express-milo--adobecom.hlx.page/express/create/poster |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

Use the screen reader to navigate the how to carousel at the bottom of the page. The screen reader should tell you when you are on a selected tab. 
---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://how-to-carousel-states--express-milo--adobecom.hlx.page/express/create/**

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
