### PR TITLE
Fix Icons Having Promises As Alt Text

### DIFF
--- a/express/code/blocks/make-a-project/make-a-project.js
+++ b/express/code/blocks/make-a-project/make-a-project.js
@@ -5,7 +5,7 @@ import buildCarousel from '../../scripts/widgets/carousel.js';
 let createTag;
 
 export default async function decorate($block) {
-  await Promise.all([import(`${getLibs()}/utils/utils.js`), fixIcons($block)]).then(([utils]) => {
+  await Promise.all([import(`${getLibs()}/utils/utils.js`), fixIcons($block,true)]).then(([utils]) => {
     ({ createTag } = utils);
   });
   addTempWrapperDeprecated($block, 'make-a-project');

--- a/express/code/blocks/steps/steps.js
+++ b/express/code/blocks/steps/steps.js
@@ -14,7 +14,7 @@ export function addBlockClasses(block, classNames) {
 export default async function decorate(block) {
   ({ createTag } = await import(`${getLibs()}/utils/utils.js`));
   addBlockClasses(block, ['step-image', 'step-description']);
-  fixIcons(block);
+  fixIcons(block, false);
 
   const section = block.closest('.section');
   const heading = section.querySelector('h2, h3, h4');

--- a/express/code/blocks/steps/steps.js
+++ b/express/code/blocks/steps/steps.js
@@ -14,7 +14,7 @@ export function addBlockClasses(block, classNames) {
 export default async function decorate(block) {
   ({ createTag } = await import(`${getLibs()}/utils/utils.js`));
   addBlockClasses(block, ['step-image', 'step-description']);
-  fixIcons(block, false);
+  fixIcons(block, true);
 
   const section = block.closest('.section');
   const heading = section.querySelector('h2, h3, h4');

--- a/express/code/blocks/steps/steps.js
+++ b/express/code/blocks/steps/steps.js
@@ -14,7 +14,7 @@ export function addBlockClasses(block, classNames) {
 export default async function decorate(block) {
   ({ createTag } = await import(`${getLibs()}/utils/utils.js`));
   addBlockClasses(block, ['step-image', 'step-description']);
-  fixIcons(block, true);
+  fixIcons(block);
 
   const section = block.closest('.section');
   const heading = section.querySelector('h2, h3, h4');

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -252,7 +252,7 @@ export function getIconElementDeprecated(icons, size, alt, additionalClassName, 
   return icon;
 }
 
-export async function fixIcons(el = document, showAltText = true) {
+export async function fixIcons(el = document, ariaHidden = false) {
   /* backwards compatible icon handling, deprecated */
   el.querySelectorAll('svg use[href^="./_icons_"]').forEach(($use) => {
     $use.setAttribute('href', `/express/icons.svg#${$use.getAttribute('href').split('#')[1]}`);
@@ -280,14 +280,13 @@ export async function fixIcons(el = document, showAltText = true) {
       });
 
     let altText = null;
-    if (showAltText) {
-      const iconPlaceholder = await replaceKey(icon, getConfig());
-      const mobileIconPlaceholder = await replaceKey(mobileIcon, getConfig());
-      if (iconPlaceholder) {
-        altText = iconPlaceholder;
-      } else if (mobileIconPlaceholder) {
-        altText = mobileIconPlaceholder;
-      }
+
+    const iconPlaceholder = await replaceKey(icon, getConfig());
+    const mobileIconPlaceholder = await replaceKey(mobileIcon, getConfig());
+    if (iconPlaceholder) {
+      altText = iconPlaceholder;
+    } else if (mobileIconPlaceholder) {
+      altText = mobileIconPlaceholder;
     }
 
     const $picture = $img.closest('picture');
@@ -303,8 +302,13 @@ export async function fixIcons(el = document, showAltText = true) {
         return;
       }
     }
+    const iconElement = getIconElementDeprecated([icon, mobileIcon], size, altText);
+    if (ariaHidden) {
+      iconElement.setAttribute('aria-hidden', 'true');
+    }
     $picture.parentElement
-      .replaceChild(getIconElementDeprecated([icon, mobileIcon], size, altText), $picture);
+      .replaceChild(iconElement, $picture);
+
   });
 }
 

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -77,8 +77,8 @@ export async function getRedirectUri() {
     return url && branchLinkOriginPattern.test(new URL(url).origin);
   }
   const url = getMetadata('pep-destination')
-      || BlockMediator.default.get('primaryCtaUrl')
-      || document.querySelector('a.button.xlarge.same-fcta, a.primaryCTA')?.href;
+    || BlockMediator.default.get('primaryCtaUrl')
+    || document.querySelector('a.button.xlarge.same-fcta, a.primaryCTA')?.href;
   return isBranchLink(url) && url;
 }
 
@@ -252,7 +252,7 @@ export function getIconElementDeprecated(icons, size, alt, additionalClassName, 
   return icon;
 }
 
-export async function fixIcons(el = document) {
+export async function fixIcons(el = document, showAltText = true) {
   /* backwards compatible icon handling, deprecated */
   el.querySelectorAll('svg use[href^="./_icons_"]').forEach(($use) => {
     $use.setAttribute('href', `/express/icons.svg#${$use.getAttribute('href').split('#')[1]}`);
@@ -267,40 +267,44 @@ export async function fixIcons(el = document) {
   /* new icons handling */
   el.querySelectorAll('img').forEach(async ($img) => {
     const alt = $img.getAttribute('alt');
-    if (alt) {
-      const lowerAlt = alt.toLowerCase();
-      if (lowerAlt.includes('icon:')) {
-        const [icon, mobileIcon] = lowerAlt
-          .split(';')
-          .map((i) => {
-            if (i) {
-              return toClassName(i.split(':')[1].trim());
-            }
-            return null;
-          });
-        let altText = null;
-        if (await replaceKey(icon, getConfig())) {
-          altText = await replaceKey(icon, getConfig());
-        } else if (await replaceKey(mobileIcon, getConfig())) {
-          altText = await replaceKey(mobileIcon, getConfig());
+    const lowerAlt = alt?.toLowerCase();
+    if (!lowerAlt?.includes('icon:')) return;
+
+    const [icon, mobileIcon] = lowerAlt
+      .split(';')
+      .map((i) => {
+        if (i) {
+          return toClassName(i.split(':')[1].trim());
         }
-        const $picture = $img.closest('picture');
-        const $block = $picture.closest('.section > div');
-        let size = 44;
-        if ($block) {
-          const blockName = $block.classList[0];
-          // use small icons in .columns (except for .columns.offer)
-          if (blockName === 'columns') {
-            size = $block.classList.contains('offer') ? 44 : 22;
-          } else if (blockName === 'toc') {
-            // ToC block has its own logic
-            return;
-          }
-        }
-        $picture.parentElement
-          .replaceChild(getIconElementDeprecated([icon, mobileIcon], size, altText), $picture);
+        return null;
+      });
+
+    let altText = null;
+    if (showAltText) {
+      const iconPlaceholder = await replaceKey(icon, getConfig());
+      const mobileIconPlaceholder = await replaceKey(mobileIcon, getConfig());
+      if (iconPlaceholder) {
+        altText = iconPlaceholder;
+      } else if (mobileIconPlaceholder) {
+        altText = mobileIconPlaceholder;
       }
     }
+
+    const $picture = $img.closest('picture');
+    const $block = $picture.closest('.section > div');
+    let size = 44;
+    if ($block) {
+      const blockName = $block.classList[0];
+      // use small icons in .columns (except for .columns.offer)
+      if (blockName === 'columns') {
+        size = $block.classList.contains('offer') ? 44 : 22;
+      } else if (blockName === 'toc') {
+        // ToC block has its own logic
+        return;
+      }
+    }
+    $picture.parentElement
+      .replaceChild(getIconElementDeprecated([icon, mobileIcon], size, altText), $picture);
   });
 }
 
@@ -325,13 +329,13 @@ export async function decorateButtonsDeprecated(el, size) {
       const { hash } = new URL($a.href);
 
       if (originalHref !== linkText
-          && !(linkText.startsWith('https') && linkText.includes('/media_'))
-          && !/hlx\.blob\.core\.windows\.net/.test(linkText)
-          && !/aem\.blob\.core\.windows\.net/.test(linkText)
-          && !linkText.endsWith(' >')
-          && !(hash === '#embed-video')
-          && !linkText.endsWith(' ›')
-          && !linkText.endsWith('.svg')) {
+        && !(linkText.startsWith('https') && linkText.includes('/media_'))
+        && !/hlx\.blob\.core\.windows\.net/.test(linkText)
+        && !/aem\.blob\.core\.windows\.net/.test(linkText)
+        && !linkText.endsWith(' >')
+        && !(hash === '#embed-video')
+        && !linkText.endsWith(' ›')
+        && !linkText.endsWith('.svg')) {
         const $up = $a.parentElement;
         const $twoup = $a.parentElement.parentElement;
         if (!$a.querySelector('img')) {
@@ -340,12 +344,12 @@ export async function decorateButtonsDeprecated(el, size) {
             $up.classList.add('button-container');
           }
           if ($up.childNodes.length === 1 && $up.tagName === 'STRONG'
-              && $twoup.children.length === 1 && $twoup.tagName === 'P') {
+            && $twoup.children.length === 1 && $twoup.tagName === 'P') {
             $a.classList.add('button', 'accent');
             $twoup.classList.add('button-container');
           }
           if ($up.childNodes.length === 1 && $up.tagName === 'EM'
-              && $twoup.children.length === 1 && $twoup.tagName === 'P') {
+            && $twoup.children.length === 1 && $twoup.tagName === 'P') {
             $a.classList.add('button', 'accent', 'light');
             $twoup.classList.add('button-container');
           }

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -252,7 +252,7 @@ export function getIconElementDeprecated(icons, size, alt, additionalClassName, 
   return icon;
 }
 
-export async function fixIcons(el = document, presentational = false) {
+export async function fixIcons(el = document, presentational = true) {
   /* backwards compatible icon handling, deprecated */
   el.querySelectorAll('svg use[href^="./_icons_"]').forEach(($use) => {
     $use.setAttribute('href', `/express/icons.svg#${$use.getAttribute('href').split('#')[1]}`);

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -252,7 +252,7 @@ export function getIconElementDeprecated(icons, size, alt, additionalClassName, 
   return icon;
 }
 
-export async function fixIcons(el = document, ariaHidden = false) {
+export async function fixIcons(el = document, presentational = false) {
   /* backwards compatible icon handling, deprecated */
   el.querySelectorAll('svg use[href^="./_icons_"]').forEach(($use) => {
     $use.setAttribute('href', `/express/icons.svg#${$use.getAttribute('href').split('#')[1]}`);
@@ -303,8 +303,8 @@ export async function fixIcons(el = document, ariaHidden = false) {
       }
     }
     const iconElement = getIconElementDeprecated([icon, mobileIcon], size, altText);
-    if (ariaHidden) {
-      iconElement.setAttribute('aria-hidden', 'true');
+    if (presentational) {
+      iconElement.setAttribute('role', 'presentation');
     }
     $picture.parentElement
       .replaceChild(iconElement, $picture);

--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -265,7 +265,7 @@ export async function fixIcons(el = document) {
     ({ replaceKey } = placeholders);
   });
   /* new icons handling */
-  el.querySelectorAll('img').forEach(($img) => {
+  el.querySelectorAll('img').forEach(async ($img) => {
     const alt = $img.getAttribute('alt');
     if (alt) {
       const lowerAlt = alt.toLowerCase();
@@ -279,10 +279,10 @@ export async function fixIcons(el = document) {
             return null;
           });
         let altText = null;
-        if (replaceKey(icon, getConfig())) {
-          altText = replaceKey(icon, getConfig());
-        } else if (replaceKey(mobileIcon, getConfig())) {
-          altText = replaceKey(mobileIcon, getConfig());
+        if (await replaceKey(icon, getConfig())) {
+          altText = await replaceKey(icon, getConfig());
+        } else if (await replaceKey(mobileIcon, getConfig())) {
+          altText = await replaceKey(mobileIcon, getConfig());
         }
         const $picture = $img.closest('picture');
         const $block = $picture.closest('.section > div');


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

fixIcons() was not properly awaiting `replaceKey` function calls, causing promises to make their way into our icon alt texts.

---

## Jira Ticket

Resolves: [MWPW-173190](https://jira.corp.adobe.com/browse/MWPW-172050)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://object-promise-icon-alt-text--express-milo--adobecom.aem.page/express/pricing |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- We expect there to be no visual regressions on the provided pages. For the pricing page provided, we expect the crown icon to have the "Premium" alt text now.
---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://object-promise-icon-alt-text--express-milo--adobecom.aem.page/express/**

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
