### PR TITLE
MWPW-173643: remove unnecessary aria labels

### DIFF
--- a/express/code/blocks/discover-cards/discover-cards.js
+++ b/express/code/blocks/discover-cards/discover-cards.js
@@ -135,11 +135,8 @@ export default async function decorate(block) {
   cardsWrapper.setAttribute('aria-label', `${numCards} cards in this section`);
 
   const cardParagraphs = [[]];
-  cards.forEach((card, index) => {
+  cards.forEach((card) => {
     card.classList.add('card');
-
-    card.setAttribute('aria-setsize', numCards);
-    card.setAttribute('aria-posinset', index + 1);
 
     const cardDivs = [...card.children];
 


### PR DESCRIPTION
## Summary

We have set the `setsize` and `posinset` aria labels to guide the users. However, this seems unncessary while the elements are already present in the DOM. User agents can handle this. Link: https://www.w3.org/TR/wai-aria-1.2/#aria-setsize

```If all items in a set are present in the document structure, it is not necessary to set this property, as the [user agent](https://www.w3.org/TR/wai-aria-1.2/#dfn-user-agent) can automatically calculate the set size and position for each item. However, if only a portion of the set is present in the document structure at a given moment (in order to reduce document size), this property is needed to provide an explicit indication of set size.```

* remove the arial label properties for this section

---

## Jira Ticket

Resolves: [MWPW-173643](https://jira.corp.adobe.com/browse/MWPW-173643)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/entitled?martech=off|
| **After**   | https://MWPW-173643--express-milo--adobecom.aem.page/express/entitled?martech=off |

---

## Verification Steps

Please include:
- Right click and Inspect the Discovery Card element.
- The element should not have aria labels, e,g. `<div class="card gallery--item" tabindex="0">`

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

It is one block, and should fix the issue on all pages and locales where it is used. Double checks areas where Discovery Cards are use and locales. 

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
