### PR TITLE
Update template-x.css

### DIFF
--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2331,7 +2331,7 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   display: flex;
   align-items: center;
   gap: 4px;
-  width: 130px;
+  min-width: 130px;
   background-color: var(--background-positive-default);
   color: white;
   text-align: center;


### PR DESCRIPTION
## Summary
Switch the hardcoded width to min-width in the "copied to clipboard" widget of the template widget.
---

## Jira Ticket
Resolves: https://jira.corp.adobe.com/browse/MWPW-172373

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://copy-to-clipboard-template--express-milo--adobecom.aem.page/express/templates |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
 Go to the template section and try using the copy button. Ensure that there is no visual regression for the widget. Check on high and low screen sizes.
---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://copy-to-clipboard-template--express-milo--adobecom.aem.page/express/templates
- https://copy-to-clipboard-template--express-milo--adobecom.aem.page/express/create

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
