### PR TITLE
Revert "Turn off Browse API Calls on Template Search Pages"

### DIFF
--- a/express/code/scripts/utils/browse-api-controller.js
+++ b/express/code/scripts/utils/browse-api-controller.js
@@ -33,10 +33,6 @@ export default async function getData() {
     .map((s) => s && String(s[0]).toUpperCase() + String(s).slice(1))
     .reverse()
     .join(' ');
-  if (textQuery === 'Search') {
-    // turn off for search pages
-    return null;
-  }
   const data = {
     experienceId,
     querySuggestion: {


### PR DESCRIPTION
reverting this since I did merge commit instead of squash. Reverts adobecom/express-milo#358