### PR TITLE
[MWPW-174225][Tech Debt] Placeholders for FQA-Mobile

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -75,12 +75,17 @@ function selectElementByTagPrefix(p) {
   return Array.from(allEls).find((e) => e.tagName.toLowerCase().startsWith(p.toLowerCase()));
 }
 
-export function runQuickAction(quickAction, data, block) {
-  // TODO: need the button labels from the placeholders sheet if the SDK default doens't work.
+const downloadKey = 'download-to-phone';
+const editKey = 'edit-in-adobe-express-for-free';
+export async function runQuickAction(quickAction, data, block) {
+  let downloadText = await replaceKey(downloadKey, getConfig());
+  if (downloadText === downloadKey.replaceAll('-', ' ')) downloadText = 'Download to Phone';
+  let editText = await replaceKey(editKey, getConfig());
+  if (editText === editKey.replaceAll('-', ' ')) editText = 'Edit in Adobe Express for free';
   const exportConfig = [
     {
       id: 'download-button',
-      label: 'Download to Phone',
+      label: downloadText,
       action: {
         target: 'download',
       },
@@ -95,7 +100,7 @@ export function runQuickAction(quickAction, data, block) {
     },
     {
       id: 'edit-in-express',
-      label: 'Edit in Adobe Express for free',
+      label: editText,
       action: {
         target: 'express',
       },


### PR DESCRIPTION
## Summary

Finish a TODO item and use placeholders rather than hardcoded texts to unblock international rollout.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-174225

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/de/express/feature/image/remove-background-new/remove-background?martech=off |
| **After**   | https://fqa-mobile-placeholders-ctas--express-milo--adobecom.aem.page/de/express/feature/image/remove-background-new/remove-background?martech=off |

---

## Verification Steps

- Use a mobile Android device or Chrome emulator to open up the link
- Upload a photo and let the iframe load
- In stage, you should see the 2 CTAs having hardcoded English values
- In dev link, you should see the 2 CTAs having "To be translated" as that's the values in placeholders sheets

---

## Potential Regressions
- Should have no visual/functional changes on any pages
- https://fqa-mobile-placeholders-ctas--express-milo--adobecom.aem.page/de/express/feature/image/remove-background?martech=off