### PR TITLE
[MWPW-173182][Sitemap] Added x-default hreflang

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -4,6 +4,7 @@ sitemaps:
   website:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
+    default: en
     languages:
       default:
         source: /express/query-index.json
@@ -99,6 +100,7 @@ sitemaps:
   blogs:
     origin: https://www.adobe.com
     lastmod: YYYY-MM-DD
+    default: en
     languages:
       default:
         source: /express/learn/blog/query-index.json
@@ -148,6 +150,7 @@ sitemaps:
 
   seo-templates:
     origin: https://www.adobe.com
+    default: en
     languages:
       default:
         source: /express/templates/default/metadata.json?sheet=sitemap
@@ -217,6 +220,7 @@ sitemaps:
 
   colors:
     origin: https://www.adobe.com
+    default: en
     languages:
       default:
         source: /express/colors/default/metadata.json?sheet=sitemap


### PR DESCRIPTION
## Summary

Added x-default hreflang attribute to our sitemaps.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-173182

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.live/express/ |
| **After**   | https://x-default-hreflang--express-milo--adobecom.aem.live/express/?martech=off |

---

## Verification Steps

- It cannot be easily verified until we deploy it to main. Once deployed, we can run the Sitemap Regenerate command and verify on https://www.adobe.com/express/sitemap.xml. If any issues were found, we can rollback right away.
- This will not have any impacts on any pages. Its impacts are limited to our sitemaps.
- We have documentations on sitemap rebuild too: https://wiki.corp.adobe.com/display/adobedotcom/Express+Sitemap+Rebuild+Documentation

---

## Additional Notes

It might be beneficial to deploy this change as a separate mini release containing itself only, for easier tracking and potential rollback.
