### PR TITLE
[MWPW-173635] Stronger Contrast Text For Pricing Table

### DIFF
--- a/express/code/blocks/pricing-table/pricing-table.css
+++ b/express/code/blocks/pricing-table/pricing-table.css
@@ -569,7 +569,7 @@ main .section .pricing-table-wrapper:has(.pricing-table.many-cols) {
   font-weight: 600;
 }
 .pricing-table .row.section-row .col .col-content em{
-  color: gray;
+  color:  var(--color-gray-600);
 }
 
 .pricing-table .row.section-row .col.included-feature .col-content {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Changes the font color from gray to --var-gray-600 to meet minimum contrast requirement.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-173635
---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://pricing-table-gray-contrast--express-milo--adobecom.aem.page/express/why-choose-express |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Run the AX full page scan and ensure any errors that pop up are unrelated to the pricing table. There may be an issue with the red button from the experiment framework, but that is not seen by consumers.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://pricing-table-gray-contrast--express-milo--adobecom.aem.page/express/why-choose-express
- https://pricing-table-gray-contrast--express-milo--adobecom.aem.page/express/pricing

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
