### PR TITLE
[MWPW-171895] Pricing Table Correct Aria

### DIFF
--- a/express/code/blocks/pricing-table/pricing-table.js
+++ b/express/code/blocks/pricing-table/pricing-table.js
@@ -48,8 +48,7 @@ function handleHeading(headingRow) {
       return;
     }
 
-   
-    col.setAttribute('id', 0 + ":" + colIdx);
+    col.setAttribute('id', `${0}:${colIdx}`);
     col.setAttribute('role', 'columnheader');
 
     col.querySelectorAll('img').forEach((img) => {
@@ -140,8 +139,8 @@ function handleSection(sectionParams) {
     row.classList.add('section-header-row');
     rowCols[0].classList.add('section-head-title');
     rowCols[0].setAttribute('role', 'rowheader');
-    rowCols[0].setAttribute('id', index + ":" + 0);
-    previousHeaderRowHeadingId =  index + ":" + 0;
+    rowCols[0].setAttribute('id', `${index}:${0}`);
+    previousHeaderRowHeadingId = `${index}:${0}`;
     previousHeaderRow = row;
   } else if (index === 0) {
     row.classList.add('row-heading', 'table-start-row');
@@ -152,7 +151,7 @@ function handleSection(sectionParams) {
       if (idx === 0) {
         col.setAttribute('aria-labelledby', previousHeaderRowHeadingId);
         col.setAttribute('role', 'rowheader');
-        col.setAttribute('id', index + ":" + idx);
+        col.setAttribute('id', `${index}:${idx}`);
         if (!col.children?.length || col.querySelector(':scope > sup')) col.innerHTML = `<p>${col.innerHTML}</p>`;
         return;
       }
@@ -163,7 +162,7 @@ function handleSection(sectionParams) {
       }
 
       if (previousHeaderRow) {
-        col.setAttribute('aria-labelledby', `${index +":" + 0} ${0 + ":" + idx}`);
+        col.setAttribute('aria-labelledby', `${`${index}:${0}`} ${`${0}:${idx}`}`);
       }
 
       const child = col.children?.[0] || col;


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Refactors the pricing table component to use proper aria attributes. Cells, row headers, and columns now use IDs to inform the screen reader properly.

Set decorative premium icon alt text to null.

---

## Jira Ticket

Resolves:  
https://jira.corp.adobe.com/browse/MWPW-171895

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/pricing |
| **After**   | https://pricing-table-v3--express-milo--adobecom.aem.page/express/pricing |

 https://pricing-table-v3--express-milo--adobecom.aem.page/express/pricing
 https://pricing-table-v3--express-milo--adobecom.aem.page/express/why-choose-express
 https://pricing-table-v3--express-milo--adobecom.aem.page/express/business
 https://pricing-table-v3--express-milo--adobecom.aem.page/express/ambassadors


---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the pages with the pricing table. Use the axe inspector widget to verify no errors are caused by the pricing table. Use the screen reader to navigate the table and ensure it functions reasonably well. The screen reader should announce the columns / rows for each cell when you visit them now.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

 https://pricing-table-v3--express-milo--adobecom.aem.page/express/pricing
 https://pricing-table-v3--express-milo--adobecom.aem.page/express/why-choose-express
 https://pricing-table-v3--express-milo--adobecom.aem.page/express/business
 https://pricing-table-v3--express-milo--adobecom.aem.page/express/ambassadors

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
