### PR TITLE
Pricing card alt text

### DIFF
--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -420,6 +420,7 @@ async function handlePrice(pricingArea, specialPromo, groupID, legacyVersion) {
 }
 
 async function createPricingSection(
+  header,
   pricingArea,
   ctaGroup,
   specialPromo,
@@ -445,6 +446,9 @@ async function createPricingSection(
     if (a.parentNode.tagName.toLowerCase() === 'p') {
       a.parentNode.remove();
     }
+
+    a.setAttribute('aria-label', a.textContent.trim() + ' ' + header.textContent.trim());
+    
     formatDynamicCartLink(a);
     ctaGroup.append(a);
   });
@@ -595,8 +599,8 @@ async function decorateCard({
   decorateBasicTextSection(explain, 'card-explain', card);
   const groupID = `${Date.now()}:${header.textContent.replace(/\s/g, '').trim()}`;
   const [mPricingSection, yPricingSection] = await Promise.all([
-    createPricingSection(mPricingRow, mCtaGroup, specialPromo, groupID, legacyVersion),
-    createPricingSection(yPricingRow, yCtaGroup, null),
+    createPricingSection(header, mPricingRow, mCtaGroup, specialPromo, groupID, legacyVersion),
+    createPricingSection(header, yPricingRow, yCtaGroup, null),
   ]);
   mPricingSection.classList.add('monthly');
   yPricingSection.classList.add('annually', 'hide');

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.js
@@ -173,6 +173,7 @@ function handleRawPrice(price, basePrice, response) {
 }
 
 async function createPricingSection(
+  header,
   pricingArea,
   ctaGroup,
 ) {
@@ -214,7 +215,9 @@ async function createPricingSection(
     if (a.textContent.includes(SALES_NUMBERS)) {
       formatSalesPhoneNumber([a], SALES_NUMBERS);
     }
+    a.setAttribute('aria-label', a.textContent.trim() + ' ' + header.textContent.trim());
   });
+  
 }
 
 function decorateHeader(header, planExplanation) {
@@ -292,6 +295,7 @@ export default async function init(el) {
     decorateCardBorder(card, rows[1].children[0]);
     decorateHeader(rows[0].children[0], rows[2].children[0]);
     await createPricingSection(
+      rows[0].children[0],
       rows[3].children[0],
       rows[4].children[0],
     );


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Adds a more descriptive aria label to the ctas of the pricing cards and simplified pricing cards blocks.

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-172615

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://pricing-card-alt-text--express-milo--adobecom.aem.page/express/ |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the pricing cards with a screen reader and select the middle CTAs.  The screen reader should tell you the contents of the button and the header of the card together.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://pricing-card-alt-text--express-milo--adobecom.aem.page/express

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
