### PR TITLE
[MWPW-173339] Multiple links have the same programmatic link text but different destinations

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.js
+++ b/express/code/blocks/ax-columns/ax-columns.js
@@ -42,6 +42,11 @@ function transformToVideoColumn(cell, aTag, block) {
       const buttonContainer = button.closest('.button-container');
       if (buttonContainer) buttonContainer.remove();
       else button.remove();
+    } else {
+      const header = parent.querySelector('h1, h2, h3, h4, h5, h6');
+      if (header) {
+        button.setAttribute('aria-label', header.textContent.trim());
+      }
     }
   });
   aTag.setAttribute('rel', 'nofollow');


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Updates the aria label of these ax-columns buttons to include the column header.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-173339

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://ax-columns-aria-label--express-milo--adobecom.aem.page/express/entitled |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

-  https://ax-columns-aria-label--express-milo--adobecom.aem.page/express/entitled

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
