### PR TITLE
MWPW-172621: set all svgs to role=presentation

### DIFF
--- a/express/code/scripts/utils.js
+++ b/express/code/scripts/utils.js
@@ -121,6 +121,7 @@ function createSVGWrapper(icon, sheetSize, alt, altSrc) {
   const svgWrapper = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svgWrapper.classList.add('icon');
   svgWrapper.classList.add(`icon-${icon}`);
+  svgWrapper.setAttribute('aria-hidden', 'true');
   svgWrapper.setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns', 'http://www.w3.org/1999/xlink');
   if (alt) {
     svgWrapper.appendChild(createTag('title', { innerText: alt }));


### PR DESCRIPTION
## Summary

Svg icons were accessible to screen readers. 

- Make SVGs icons aria-label-hidden true to hide svgs from screen readers.

---

## Jira Ticket

Resolves: [MWPW-172621](https://jira.corp.adobe.com/browse/MWPW-172621)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/feature/image/convert/jpg-to-png |
| **After**   | https://mwpw-172621--express-milo--adobecom.aem.page/express/feature/image/convert/jpg-to-png?martech=off |
---

## Verification Steps

Please include:
- Load the page, and locate the How To component.
- Right click on the icons on the block.
- What to expect **before**  there was no aria-label-hidden and **after** we see the aria-label-hidden set to true.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
