### PR TITLE
MWPW-172516: remove : and extra line

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -254,7 +254,6 @@ function renderCTALink(branchUrl, template) {
     tabindex: '-1',
     'aria-label': `${btnTitle} ${getTemplateTitle(template)}`,
   });
-  linkEl.setAttribute('aria-label', `${editThisTemplate}: ${getTemplateTitle(template)}`);
   return linkEl;
 }
 


### PR DESCRIPTION
## Summary

As part of the arial label update to add context, they wanted to remove the `:` 
change`Edit this template: Grey Handwritten Wellness Logo` 
to `Edit this template Grey Handwritten Wellness Logo` 

We did some work on the PRs below, but missed this one part.

---

## Jira Ticket

Resolves: [MWPW-172516](https://jira.corp.adobe.com/browse/MWPW-172516)

Related to: https://github.com/adobecom/express-milo/pull/342, https://github.com/adobecom/express-milo/pull/346

---

## Test URLs
| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/create/logo?martech=off  |
| **After**   | https://mwpw-172516--express-milo--adobecom.aem.page/express/create/logo?martech=off |

---

## Verification Steps

Please include:
- locate the Template block
- Inspect the template image element by right clicking on it.
- **before** links aria-label contained `:` **after** the change it should not contain the `:`

---

## Potential Regressions

List any areas or URLs that could be affected by this change:
- https://mwpw-172516--express-milo--adobecom.aem.page/express/feature/image/editor?martech=off
- https://mwpw-172516--express-milo--adobecom.aem.page/express/create/brochure?martech=off
- https://mwpw-172516--express-milo--adobecom.aem.page/express/templates/?martech=off
---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
