### PR TITLE
Update template api headers

### DIFF
--- a/express/code/scripts/template-search-api-v3.js
+++ b/express/code/scripts/template-search-api-v3.js
@@ -96,7 +96,7 @@ function formatFilterString(filters) {
     if (langFilter) str += `&filters=language==${langFilter}`;
 
     // No Region Filter as template region tagging is still inconsistent.
-    // We still have Region Boosting via x-express-ims-region-code header
+    // We still have Region Boosting via x-express-pref-region-code header
     // const regionFilter = extractRegions(locales).join(',');
     // if (regionFilter) str += `&filters=applicableRegions==${regionFilter}`;
   }
@@ -248,7 +248,7 @@ async function fetchSearchUrl({
   const headers = {};
   const prefLang = getConfig().locales?.[langs[0] === 'en' ? '' : langs[0]]?.ietf;
   const [prefRegion] = extractRegions(filters.locales);
-  headers['x-express-ims-region-code'] = prefRegion; // Region Boosting
+  headers['x-express-pref-region-code'] = prefRegion; // Region Boosting
   if (prefLang && supportedLanguages.includes(prefLang)) {
     headers['x-express-pref-lang'] = prefLang; // Language Boosting
   }


### PR DESCRIPTION
## Summary

---

Update a header name when calling template api to address CORS error on lower envs.
Documentation: https://git.corp.adobe.com/pages/project-marvel/content-search-service/#/Search%20V3/searchContentUsingGET

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/templates/ |
| **After**   | https://template-region-code-header--express-milo--adobecom.aem.page/express/templates/?martech=off |

---

## Verification Steps
- On stage link, template-x-block should fail to load due to CORS error
- On Dev branch link, it should load normally

---

## Potential Regressions

Template-X is also used in create and color pages and many others:
- https://template-region-code-header--express-milo--adobecom.aem.live/express/colors/periwinkle?martech=off
- https://template-region-code-header--express-milo--adobecom.aem.live/express/create/card/christmas?martech=off

