### PR TITLE
[MWPW-172373] Text Spacing Share Link V2

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -167,7 +167,9 @@ function renderShareWrapper(templateInfo) {
   });
   const checkmarkIcon = getIconElementDeprecated('checkmark-green');
   tooltip.append(checkmarkIcon);
-  tooltip.append(text);
+  const textEl = createTag('span', { class: 'text' });
+  textEl.textContent = text;
+  tooltip.append(textEl);
   wrapper.append(shareIcon);
   wrapper.append(tooltip);
   return wrapper;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2332,7 +2332,6 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   align-items: center;
   gap: 4px;
   min-width: 130px;
-  width: fit-content;
   background-color: var(--background-positive-default);
   color: white;
   text-align: center;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2332,11 +2332,12 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   align-items: center;
   gap: 4px;
   min-width: 130px;
+  width: fit-content;
   background-color: var(--background-positive-default);
   color: white;
   text-align: center;
   border-radius: 6px;
-  padding: 6px;
+  padding: 0.5rem;
   top: 50%;
   transform: translateY(-50%);
   left: calc(100% + 12px);

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2342,6 +2342,10 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   transform: translateY(-50%);
   left: calc(100% + 12px);
   font-size: var(--body-font-size-s);
+  width: max-content;
+  max-width: 200px;
+  white-space: normal;
+  word-break: break-word;
 }
 
 .template-x.horizontal .template:nth-last-of-type(2) .button-container .media-wrapper .share-icon-wrapper .shared-tooltip {


### PR DESCRIPTION
## Summary

Per Taryn's feedback, I've made a second PR addressing the ticket.

This PR addresses an accessibility issue where the "Copied to Clipboard" status message displays with insufficient color contrast (white on white) when text spacing is applied. This specifically impacts users with limited vision or without perception of color, violating WCAG 1.4.3 Contrast (Minimum) (Level AA). The fix involves adjusting the styling of the "Copied to Clipboard" tag to ensure proper contrast and responsiveness to text length under text spacing conditions.

---

## Jira Ticket

Resolves: [MWPW-172373](https://jira.corp.adobe.com/browse/MWPW-172373)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before** | https://main--express-milo--adobecom.aem.page/express/ |
| **After** | https://text-spacing-template-x--express-milo--adobecom.hlx.page/express/templates/ |

---

## Verification Steps

1.  Open the "After" URL in a browser.
2.  Use the Text Spacing Extension and set it to WCAG values.
3.  Navigate to any template and activate its share button.
4.  Observe the "Copied to Clipboard" status message that appears.

**Expected results (After):**
The "Copied to Clipboard" status message text should have a color contrast ratio of at least 4.5:1 with its background, ensuring it is clearly visible even with text spacing applied. The text should also be fully visible and not cut off.

**Actual results (Before):**
The "Copied to Clipboard" status message text (`#FFFFFF`) appears on a white background (`#FFFFFF`), resulting in a 1.00:1 contrast ratio, making it unreadable. The text might also be cut off.

---

## Potential Regressions

-   https://text-spacing-template-x--express-milo--adobecom.hlx.page/express/templates/


