### PR TITLE
[MWPW-174751][NALA] Enable `run-nala` GitHub Action Job 

### DIFF
--- a/nala/utils/nala.run.cjs
+++ b/nala/utils/nala.run.cjs
@@ -69,15 +69,15 @@ function parseArgs(args) {
       parsedParams.tag = value;
     } else if (arg.startsWith('@')) {
       parsedParams.tag += parsedParams.tag ? ` ${arg.substring(1)}` : arg.substring(1);
-    } else if (arg.endsWith('.test.js')) {
+    } else if (arg.endsWith('.test.cjs')) {
       parsedParams.test = arg;
-    } else if (arg.endsWith('.config.js')) {
+    } else if (arg.endsWith('.config.cjs')) {
       parsedParams.config = arg;
     } else if (['ui', 'debug', 'headless', 'headed'].includes(arg)) {
       parsedParams.mode = arg;
     } else if (arg.startsWith('repo=')) {
       const repo = arg.split('=')[1];
-      parsedParams.repo = repo || 'milo';
+      parsedParams.repo = repo || 'express-milo';
     } else if (arg.startsWith('owner=')) {
       const owner = arg.split('=')[1];
       parsedParams.owner = owner || 'adobecom';
@@ -94,7 +94,7 @@ function parseArgs(args) {
   return parsedParams;
 }
 
-function getLocalTestLiveUrl(env, milolibs, repo = 'milo', owner = 'adobecom') {
+function getLocalTestLiveUrl(env, milolibs, repo = 'express-milo', owner = 'adobecom') {
   if (milolibs) {
     process.env.MILO_LIBS = `?milolibs=${milolibs}`;
     if (env === 'local') {

--- a/nala/utils/pr.run.sh
+++ b/nala/utils/pr.run.sh
@@ -90,7 +90,7 @@ npx playwright install --with-deps
 # Run Playwright tests on the specific projects using root-level playwright.config.js
 # This will be changed later
 echo "*** Running tests on specific projects ***"
-npx playwright test --config=./playwright.config.js ${TAGS} ${EXCLUDE_TAGS} --project=express-live-chromium --project=express-live-firefox --project=express-live-webkit ${REPORTER} || EXIT_STATUS=$?
+npx playwright test --config=./playwright.config.cjs ${TAGS} ${EXCLUDE_TAGS} --project=express-live-chromium --project=express-live-firefox --project=express-live-webkit ${REPORTER} || EXIT_STATUS=$?
 
 # Check if tests passed or failed
 if [ $EXIT_STATUS -ne 0 ]; then


### PR DESCRIPTION
## Summary

- Enable the `run-nala` GitHub Action Job
- Rename `config.js` to `config.cjs` to allow execution of Nala tests when the `run-nala` label is applied
---

## Jira Ticket

Resolves: [MWPW-174751](https://jira.corp.adobe.com/browse/MWPW-174751)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://run-nala-label--express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Add the `run-nala` label to any open Pull Request in the express-milo repository.
- Observe if the Nala GitHub Action workflow is triggered.
- Ensure that the `config.cjs` file is correctly recognized and test execution begins without module resolution errors.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://run-nala-label--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
