### PR TITLE
[MWPW-172477] Frictionless QA Text Spacing 

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -74,7 +74,9 @@
     padding: 24px 0;
     border-radius: 20px;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.3);
-    height: 284px;
+    min-height: 284px;
+    display: flex;
+    flex-direction: column; 
 }
 
 .frictionless-quick-action .dropzone-bg {
@@ -96,8 +98,7 @@
 }
 
 .frictionless-quick-action .dropzone {
-    height: 100%;
-    width: 100%;
+    flex-grow: 1;
     position: relative;
 }
 

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -98,10 +98,6 @@
     padding-right: 36px;
 }
 
-.frictionless-quick-action .dropzone > p:last-of-type {
-    padding-bottom: 5px;
-}
-
 .frictionless-quick-action .dropzone > * {
     padding-left: 36px;
     padding-right: 36px;
@@ -142,7 +138,7 @@
     background-color: unset;
     flex-direction: row;
     padding: unset;
-    margin: 16px auto 0 auto;
+    margin: 16px auto 8px auto;
     gap: 8px;
     flex-wrap: wrap;
 }

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -81,7 +81,6 @@
     width: 100%;
     height: 100%;
     left: 0px;
-    background: url("/express/code/icons/dash-rectangle.svg") center center / 91% no-repeat;
 }
 
 .frictionless-quick-action .dropzone-container.highlight .dropzone-bg {
@@ -199,8 +198,7 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     .frictionless-quick-action .dropzone-bg{
         display: block;
     }
-    .frictionless-quick-action video,
-    .frictionless-quick-action img:not(.icon) {
+    .frictionless-quick-action video {
         max-width: var(--frictionless-quick-action-video-width);
     }
 

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -135,6 +135,7 @@
     padding: unset;
     margin: 16px auto 0 auto;
     gap: 8px;
+    flex-wrap: wrap;
 }
 
 .frictionless-quick-action .free-plan-widget > div {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -93,6 +93,15 @@
     background-size: 90% 100%
 }
 
+.frictionless-quick-action .dropzone > * {
+    padding-left: 36px;
+    padding-right: 36px;
+}
+
+.frictionless-quick-action .dropzone > p:last-of-type {
+    padding-bottom: 5px;
+}
+
 .frictionless-quick-action .dropzone > p:first-of-type {
     margin: 0;
     padding: 39px 24px 0 24px;

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -74,14 +74,15 @@
     display: flex;
     flex-direction: column; 
 }
-
-.frictionless-quick-action .dropzone-bg {
-    display: none;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    left: 0px;
-}
+/* 
+    .frictionless-quick-action .dropzone-bg {
+        display: none;
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        left: 0px;
+        background-image: url('/express/code/icons/dash-rectangle.svg');
+    } */
 
 .frictionless-quick-action .dropzone-container.highlight .dropzone-bg {
     filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(327deg) brightness(6%) contrast(104%);
@@ -95,9 +96,14 @@
 .frictionless-quick-action .dropzone {
     flex-grow: 1;
     position: relative;
+    background-image: url('/express/code/icons/dash-rectangle.svg');
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: 90% 100%
 }
 
-.frictionless-quick-action .dropzone-bg + p {
+.frictionless-quick-action .dropzone > p:first-of-type {
     margin: 0;
     padding: 39px 24px 0 24px;
     font-size: var(--heading-font-size-m);
@@ -105,7 +111,7 @@
     line-height: var(--heading-line-height);
 }
 
-.frictionless-quick-action .dropzone-bg + p em {
+.frictionless-quick-action  .dropzone > p:first-of-type em {
     font-style: normal;
     color: var(--color-info-accent);
 }

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -64,10 +64,6 @@
     max-width: 638px;
 }
 
-.frictionless-quick-action video,
-.frictionless-quick-action img:not(.icon) {
-    max-width: var(--frictionless-quick-action-video-width);
-}
 
 .frictionless-quick-action .dropzone-container {
     cursor: pointer;
@@ -80,7 +76,6 @@
 }
 
 .frictionless-quick-action .dropzone-bg {
-    display: none;
     position: absolute;
     width: 100%;
     height: 100%;
@@ -203,6 +198,11 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     .frictionless-quick-action .dropzone-bg{
         display: block;
     }
+    .frictionless-quick-action video,
+    .frictionless-quick-action img:not(.icon) {
+        max-width: var(--frictionless-quick-action-video-width);
+    }
+
 }
 
 @media (min-width: 1200) {

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -74,15 +74,6 @@
     display: flex;
     flex-direction: column; 
 }
-/* 
-    .frictionless-quick-action .dropzone-bg {
-        display: none;
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        left: 0px;
-        background-image: url('/express/code/icons/dash-rectangle.svg');
-    } */
 
 .frictionless-quick-action .dropzone-container.highlight .dropzone-bg {
     filter: invert(0%) sepia(0%) saturate(7500%) hue-rotate(327deg) brightness(6%) contrast(104%);
@@ -96,7 +87,6 @@
 .frictionless-quick-action .dropzone {
     flex-grow: 1;
     position: relative;
-    background-image: url('/express/code/icons/dash-rectangle.svg');
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -201,8 +191,8 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
 }
 
 @media (min-width: 768px) {
-    .frictionless-quick-action .dropzone-bg{
-        display: block;
+    .frictionless-quick-action .dropzone{
+        background-image: url('/express/code/icons/dash-rectangle.svg');
     }
     .frictionless-quick-action video {
         max-width: var(--frictionless-quick-action-video-width);

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -76,6 +76,7 @@
 }
 
 .frictionless-quick-action .dropzone-bg {
+    display: none;
     position: absolute;
     width: 100%;
     height: 100%;

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -356,7 +356,7 @@ export default async function decorate(block) {
   const animationContainer = actionAndAnimationRow[0];
   const animation = animationContainer.querySelector('a');
   const dropzone = actionAndAnimationRow[1];
-  const dropzoneBackground = createTag('div', { class: 'dropzone-bg' });
+  const dropzoneBackground = createTag('img', { class: 'dropzone-bg', src:  '/express/code/icons/dash-rectangle.svg' });
   const cta = dropzone.querySelector('a.button, a.con-button');
   const gtcText = dropzone.querySelector('p:last-child');
   const actionColumn = createTag('div');

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -355,8 +355,7 @@ export default async function decorate(block) {
   const actionAndAnimationRow = rows[1].children;
   const animationContainer = actionAndAnimationRow[0];
   const animation = animationContainer.querySelector('a');
-  const dropzone = actionAndAnimationRow[1];
-  const dropzoneBackground = createTag('img', { class: 'dropzone-bg', src: '/express/code/icons/dash-rectangle.svg' });
+  const dropzone = actionAndAnimationRow[1]; 
   const cta = dropzone.querySelector('a.button, a.con-button');
   const gtcText = dropzone.querySelector('p:last-child');
   const actionColumn = createTag('div');
@@ -374,8 +373,7 @@ export default async function decorate(block) {
 
   if (cta) cta.classList.add('xlarge');
   dropzone.classList.add('dropzone');
-
-  dropzone.prepend(dropzoneBackground);
+ 
   dropzone.before(actionColumn);
   dropzoneContainer.append(dropzone);
   actionColumn.append(dropzoneContainer, gtcText);

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -356,7 +356,7 @@ export default async function decorate(block) {
   const animationContainer = actionAndAnimationRow[0];
   const animation = animationContainer.querySelector('a');
   const dropzone = actionAndAnimationRow[1];
-  const dropzoneBackground = createTag('img', { class: 'dropzone-bg', src:  '/express/code/icons/dash-rectangle.svg' });
+  const dropzoneBackground = createTag('img', { class: 'dropzone-bg', src: '/express/code/icons/dash-rectangle.svg' });
   const cta = dropzone.querySelector('a.button, a.con-button');
   const gtcText = dropzone.querySelector('p:last-child');
   const actionColumn = createTag('div');

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -355,7 +355,7 @@ export default async function decorate(block) {
   const actionAndAnimationRow = rows[1].children;
   const animationContainer = actionAndAnimationRow[0];
   const animation = animationContainer.querySelector('a');
-  const dropzone = actionAndAnimationRow[1]; 
+  const dropzone = actionAndAnimationRow[1];
   const cta = dropzone.querySelector('a.button, a.con-button');
   const gtcText = dropzone.querySelector('p:last-child');
   const actionColumn = createTag('div');
@@ -373,7 +373,7 @@ export default async function decorate(block) {
 
   if (cta) cta.classList.add('xlarge');
   dropzone.classList.add('dropzone');
- 
+
   dropzone.before(actionColumn);
   dropzoneContainer.append(dropzone);
   actionColumn.append(dropzoneContainer, gtcText);

--- a/express/code/icons/dash-rectangle.svg
+++ b/express/code/icons/dash-rectangle.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="552" height="272" viewBox="0 0 552 272">
+<svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" width="552" height="272" viewBox="0 0 552 272">
   <g id="Rectangle_360209" data-name="Rectangle 360209" fill="none" stroke="#b6b6b6" stroke-linecap="round" stroke-width="4" stroke-dasharray="16">
     <rect width="552" height="272" rx="20" stroke="none"/>
     <rect x="2" y="2" width="548" height="268" rx="18" fill="none"/>


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Restyles the frictionless QA dropzone to use more responsive styling so that information and visual elements are preserved at 320px and when the user uses the text spacing plugin.

Restyles the video element so that it is responsive at mobile sizes and so that the pause button is now fully in the view port at all screen sizes.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-172477
---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   |  https://mwpw-172477-frictionless-qa--express-milo--adobecom.hlx.page/express/feature/image/remove-background |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Use the text spacing plugin on the frictionless QA page at 320px, verify that you can see the same information as you can on higher screen widths.
---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://mwpw-172477-frictionless-qa--express-milo--adobecom.hlx.page/express/feature/image/remove-background

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.

<img width="302" alt="Screenshot 2025-06-10 at 9 03 29 AM" src="https://github.com/user-attachments/assets/332fdb8c-1eee-4c50-b26f-7f4a83cabb99" />
<img width="1051" alt="Screenshot 2025-06-10 at 9 05 51 AM" src="https://github.com/user-attachments/assets/c05a02cb-f3cd-47b8-bbe0-6da4153a8932" />
<img width="1700" alt="Screenshot 2025-06-10 at 9 05 56 AM" src="https://github.com/user-attachments/assets/c4fc238f-8c28-467c-a709-8ab2a93d28bb" />
<img width="1786" alt="Screenshot 2025-06-10 at 9 06 05 AM" src="https://github.com/user-attachments/assets/f51403fd-da11-4ebd-901a-c5573c5e7884" />
<img width="1081" alt="Screenshot 2025-06-10 at 9 06 11 AM" src="https://github.com/user-attachments/assets/af3aa471-fadc-428e-94a0-df8ddbf8274c" />
<img width="328" alt="Screenshot 2025-06-10 at 9 06 27 AM" src="https://github.com/user-attachments/assets/52b35c8a-d3d7-4989-8018-72c8191a888b" />

