### PR TITLE
[MWPW-173725] Hidden or empty element receives focus 

### DIFF
--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.css
@@ -254,6 +254,10 @@
   padding-right: 10px;
 }
 
+.fullscreen-marquee .fullscreen-marquee-app-frame-highlight .quick-link {
+  pointer-events: none;
+}
+
 /* disable budoux on small screens  */
 @media (max-width: 600px) {
   h1.budoux {
@@ -320,3 +324,5 @@
     margin-bottom: 0;
   }
 }
+
+

--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -56,6 +56,11 @@ async function addMarqueeCenterCTA(block, appFrame) {
   const cta = buttons[0];
 
   const highlightCta = cta.cloneNode(true);
+  highlightCta.setAttribute('href', '#');
+  highlightCta.setAttribute('aria-hidden', 'true');
+  highlightCta.setAttribute('role', 'presentation');
+  highlightCta.setAttribute('tabindex', '-1');
+
   const appHighlight = createTag('a', {
     class: 'fullscreen-marquee-app-frame-highlight',
     href: cta.href,


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Makes the quick link button in the middle of the fullscreen marquee purely decorative. Removes the link, removes it from the tab order, sets its role to presentation so that screen readers ignore it while sighted users can still use it. Click events now pass through it to the parent link behind it.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-173725

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://MWPW-173725-remove-extra-link--express-milo--adobecom.aem.page/es/express/create/poster |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Use the screen reader to navigate through the fullscreen marquee. When tabbing, the center quick link button should not appear or be mentioned by the screen reader. You should still be able to hover over and be taken to the external link otherwise.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://MWPW-173725-remove-extra-link--express-milo--adobecom.aem.page/es/express/create/poster

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
