### PR TITLE
[MWPW-173640] Grid Marquee Additional content not dismissible

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -311,4 +311,3 @@ document.addEventListener('keydown', (e) => {
     drawerOff();
   }
 });
-

--- a/express/code/blocks/grid-marquee/grid-marquee.js
+++ b/express/code/blocks/grid-marquee/grid-marquee.js
@@ -140,6 +140,7 @@ function addCardInteractions(card, drawer) {
     drawerOff();
   });
 }
+
 function toCard(drawer) {
   const titleText = drawer.querySelector('strong').textContent.trim();
   const [face, ...panels] = [...drawer.querySelectorAll(':scope > div')];
@@ -304,3 +305,10 @@ export default async function init(el) {
     drawerOff();
   });
 }
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape' && currDrawer) {
+    e.preventDefault();
+    drawerOff();
+  }
+});
+


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-173640

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://MWPW-173640-dismiss-content--express-milo--adobecom.aem.page/express/ |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Hover over the grid marquee cards and press Escape. The drawer should disappear.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://MWPW-173640-dismiss-content--express-milo--adobecom.aem.page/express/

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
