### PR TITLE
[Bug] Long-Form & FAQ Blocks Not Rending Correctly on Staging - SPACING

### DIFF
--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -415,8 +415,12 @@
 
 .faqv2.longform.expandable .faqv2-header {
   padding-left: 0;
+}
+
+.faqv2.expandable.longform .faqv2-wrapper:first-child .faqv2-header {
   padding-top: 32px;
 }
+
 
 @media (min-width: 400px) {
   .faqv2-header {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -379,9 +379,7 @@
 
 .faqv2.expandable .faqv2-accordion.title {
   margin-top: 64px;
-  padding-top: 0px;
-  padding-left: 16px;
-  padding-right: 16px;
+  padding: 0 16px 32px;
 }
 
 .faqv2-grey-bg {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -73,6 +73,7 @@
 .faqv2.expandable.longform .faqv2-content.open {
   margin-top: 0;
   padding-right: 30px;
+  padding-bottom: 32px;
 }
 
 .faqv2.bold {
@@ -491,12 +492,7 @@
     padding-right: 60px;
     max-height: 0;
   }
-  
-  .faqv2.expandable.longform .faqv2-content.open {
-    margin-top: 0;
-    padding-right: 60px;
-    padding-bottom: 32px;
-  }
+
 }
 
 @media (min-width: 900px) {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -328,7 +328,7 @@
   font-weight: 400;
   margin-top: 0;
   padding-bottom: 10px;
-  padding-left: 24px;
+  padding-left: 30px;
   padding-right: 16px;
 }
 

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -64,7 +64,6 @@
   overflow: hidden;
   transition: max-height 300ms ease-out;
   margin-top: 0;
-  padding-top: 16px;
   padding-left: 18px;
   padding-right: 30px;
   max-height: 0;
@@ -72,7 +71,6 @@
 
 .faqv2.expandable.longform .faqv2-content.open {
   margin-top: 0;
-  padding-top: 16px;
   padding-left: 18px;
   padding-right: 30px;
 }
@@ -488,16 +486,14 @@
     overflow: hidden;
     transition: max-height 300ms ease-out;
     margin-top: 0;
-    padding-top: 16px;
-    padding-left: 18px;
+    padding-left: 21px;
     padding-right: 60px;
     max-height: 0;
   }
   
   .faqv2.expandable.longform .faqv2-content.open {
     margin-top: 0;
-    padding-top: 16px;
-    padding-left: 18px;
+    padding-left: 21px;
     padding-right: 60px;
   }
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -207,6 +207,10 @@
   background: unset;
 }
 
+.faqv2.expandable.longform .faqv2-accordion.expandable.header-accordion {
+  box-shadow: none;
+}
+
 /* border-radius: 8px 8px 0 0; */
 .faqv2-accordion.expandable.sub-header-accordion {
   height: 0;

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -29,6 +29,19 @@
 
 .faqv2.expandable .faqv2-wrapper {
   margin: 16px auto 6px auto;
+  box-shadow: 0px 1px 6px 0px rgba(0, 0, 0, 0.12);
+  position: relative;
+}
+
+.faqv2.expandable:not(.longform) .faqv2-wrapper::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 5px;
+  height: 100%;
+  background: linear-gradient(180deg, #FF4885 0.58%, #FC7D00 99.99%), linear-gradient(180deg, #D600C4 20%, #4B2BEE 100%);
+  border-radius: 8px 0 0 8px;
 }
 
 .faqv2 .has-background picture img {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -48,11 +48,19 @@
 }
 
 .faqv2.expandable.longform .faqv2-content {
+  overflow: hidden;
+  transition: max-height 300ms ease-out;
+  margin-top: 0;
+  padding-top: 16px;
   padding-left: 18px;
   padding-right: 30px;
+  max-height: 0;
 }
 
 .faqv2.expandable.longform .faqv2-content.open {
+  margin-top: 0;
+  padding-top: 16px;
+  padding-left: 18px;
   padding-right: 30px;
 }
 
@@ -472,6 +480,7 @@
     padding-top: 16px;
     padding-left: 18px;
     padding-right: 60px;
+    max-height: 0;
   }
   
   .faqv2.expandable.longform .faqv2-content.open {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -283,6 +283,7 @@
 .faqv2.expandable.longform .faqv2-accordion.expandable.sub-header-accordion.collapsed {
   border-radius: '8px 8px 0 0';
   margin-bottom: 0;
+  box-shadow: none;
 }
 
 .faqv2-header.expandable {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -722,13 +722,16 @@
 
 .faqv2.expandable:not(.longform) .faqv2-content.open {
   margin-top: 0;
-  padding-top: 16px;
-  padding-left: 18px;
-  padding-right: 30px;
-  padding-bottom: 16px;
+  padding: 16px 30px 16px 18px;
   background-color: #FAFAFA;
 }
 
 .faqv2.expandable:not(.longform) .faqv2-toggle:has(.faqv2-content.open) {
   background-color: #FAFAFA;
+}
+
+.faqv2 .toggle-icon {
+  width: 12px;
+  height: 12px;
+  transition: transform 0.3s ease;
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -18,8 +18,6 @@
   opacity: 0.8;
   margin-bottom: 0;
   border-radius: 0;
-  padding-top: 10px;
-  padding-bottom: 10px;
   position: relative;
 }
 
@@ -64,14 +62,12 @@
   overflow: hidden;
   transition: max-height 300ms ease-out;
   margin-top: 0;
-  padding-left: 18px;
   padding-right: 30px;
   max-height: 0;
 }
 
 .faqv2.expandable.longform .faqv2-content.open {
   margin-top: 0;
-  padding-left: 18px;
   padding-right: 30px;
 }
 
@@ -184,9 +180,7 @@
   content: '';
   position: absolute;
   bottom: 0;
-  left: 3%;
-  right: 5%;
-  width: 90%;
+  width: 100%;
   border-bottom: 1px solid #8F8F8F;
 }
 
@@ -486,15 +480,14 @@
     overflow: hidden;
     transition: max-height 300ms ease-out;
     margin-top: 0;
-    padding-left: 21px;
     padding-right: 60px;
     max-height: 0;
   }
   
   .faqv2.expandable.longform .faqv2-content.open {
     margin-top: 0;
-    padding-left: 21px;
     padding-right: 60px;
+    padding-bottom: 32px;
   }
 }
 
@@ -661,10 +654,6 @@
   }
 }
 
-.faqv2.expandable.longform .faqv2-toggle {
-  padding: 16px 0;
-}
-
 .faqv2.expandable.longform .faqv2-toggle:not(:last-child) {
   border-bottom: 1px solid #8F8F8F;
 }
@@ -678,6 +667,7 @@
   justify-content: space-between;
   align-items: center;
   padding-right: 16px;
+  padding-left: 0;
 }
 
 .faqv2.expandable .faqv2-toggle:not(:last-child) {
@@ -700,7 +690,6 @@
   transition: max-height 300ms ease-out;
   margin-top: 0;
   padding-top: 0;
-  padding-left: 21px;
   padding-right: 30px;
   max-height: 0;
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -135,8 +135,13 @@
     2px 0 4px -2px rgba(0, 0, 0, 0.1);    
 }
 
+.faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper {
+  margin-top: 0;
+}
+
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:last-child {
   border-radius: 0 0 16px 16px;
+  box-shadow: 0 4px 10px -4px rgba(0, 0, 0, 0.2);
 }
 
 .faqv2.expandable.longform .faqv2-wrapper:not(:last-child)::after {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -74,6 +74,7 @@
   margin-top: 0;
   padding-right: 30px;
   padding-bottom: 32px;
+  line-height: 130%;
 }
 
 .faqv2.bold {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -273,7 +273,7 @@
   background: transparent;
 }
 
-.faqv2-accordion.expandable.sub-header-accordion.collapsed {
+.faqv2-accordion.expandable.sub-header-accordion.open {
   height: 100%;
   opacity: 1;
   visibility: visible;
@@ -284,15 +284,15 @@
   transition: all 0.3s ease;
 }
 
-.faqv2-accordion.expandable.sub-header-accordion.collapsed::before {
+.faqv2-accordion.expandable.sub-header-accordion.open::before {
   opacity: 1;
 }
 
-.faqv2.longform .faqv2-accordion.expandable.sub-header-accordion.collapsed::before {
+.faqv2.longform .faqv2-accordion.expandable.sub-header-accordion.open::before {
   opacity: 0;
 }
 
-.faqv2-accordion.expandable.sub-header-accordion.collapsed::after {
+.faqv2-accordion.expandable.sub-header-accordion.open::after {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
@@ -300,7 +300,7 @@
   background: unset;
 }
 
-.faqv2.expandable.longform .faqv2-accordion.expandable.sub-header-accordion.collapsed {
+.faqv2.expandable.longform .faqv2-accordion.expandable.sub-header-accordion.open {
   border-radius: '8px 8px 0 0';
   margin-bottom: 0;
   box-shadow: none;
@@ -382,7 +382,7 @@
   max-width: none;
 }
 
-.faqv2-accordion.collapsed {
+.faqv2-accordion.open {
   display: none;
 }
 

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -135,13 +135,16 @@
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:first-child {
   border-radius: 16px 16px 0 0;
   box-shadow: 
-    0 -2px 4px -2px rgba(0, 0, 0, 0.1),
-   -2px 0 4px -2px rgba(0, 0, 0, 0.1),   
-    2px 0 4px -2px rgba(0, 0, 0, 0.1);    
+  0 -2px 5px -2px rgba(0, 0, 0, 0.1),
+ -2px 0 5px -2px rgba(0, 0, 0, 0.1),
+  2px 0 5px -2px rgba(0, 0, 0, 0.1);
 }
 
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper {
   margin-top: 0;
+  box-shadow: 
+  -2px 0 5px -2px rgba(0, 0, 0, 0.1),
+   2px 0 5px -2px rgba(0, 0, 0, 0.1);
 }
 
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:last-child {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -33,6 +33,10 @@
   position: relative;
 }
 
+.faqv2.expandable:not(.longform) .faqv2-toggle {
+  padding: 12px 0 0;
+}
+
 .faqv2.expandable:not(.longform) .faqv2-wrapper::before {
   content: '';
   position: absolute;
@@ -704,7 +708,6 @@
   justify-content: space-between;
   align-items: center;
   padding-right: 16px;
-  margin-bottom: 16px;
 }
 
 .faqv2.expandable .faqv2-content {
@@ -722,6 +725,7 @@
   padding-top: 16px;
   padding-left: 18px;
   padding-right: 30px;
+  padding-bottom: 16px;
   background-color: #FAFAFA;
 }
 

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -520,6 +520,7 @@
     margin-top: 25px;
     background: rgba(255, 255, 255, 0.65);
     max-width: 1300px;
+    min-height: 600px;
   }
 
   .faqv2.longform .faqv2-longform-header-container {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -374,7 +374,7 @@
 
 .faqv2.expandable .faqv2-accordion.title {
   margin-top: 64px;
-  padding: 0 16px 32px;
+  padding: 0 16px 24px;
 }
 
 .faqv2-grey-bg {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -129,6 +129,10 @@
 
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:first-child {
   border-radius: 16px 16px 0 0;
+  box-shadow: 
+    0 -2px 4px -2px rgba(0, 0, 0, 0.1),
+   -2px 0 4px -2px rgba(0, 0, 0, 0.1),   
+    2px 0 4px -2px rgba(0, 0, 0, 0.1);    
 }
 
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:last-child {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -620,3 +620,39 @@
     height: 80px;
   }
 }
+
+.faqv2.expandable.longform .faqv2-toggle {
+  padding: 16px 0;
+}
+
+.faqv2.expandable.longform .faqv2-toggle:not(:last-child) {
+  border-bottom: 1px solid #8F8F8F;
+}
+
+.faqv2.expandable.longform .faqv2-header {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-gray-800);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 16px;
+  margin-bottom: 16px;
+}
+
+.faqv2.expandable.longform .faqv2-content {
+  overflow: hidden;
+  transition: max-height 300ms ease-out;
+  margin-top: 0;
+  padding-top: 16px;
+  padding-left: 18px;
+  padding-right: 60px;
+}
+
+.faqv2.expandable.longform .faqv2-content.open {
+  margin-top: 0;
+  padding-top: 16px;
+  padding-left: 18px;
+  padding-right: 60px;
+}

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -732,5 +732,6 @@
 .faqv2 .toggle-icon {
   width: 12px;
   height: 12px;
+  margin-left: 22px;
   transition: transform 0.3s ease;
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -717,7 +717,7 @@
   max-height: 0;
 }
 
-.faqv2.expandable .faqv2-content.open {
+.faqv2.expandable:not(.longform) .faqv2-content.open {
   margin-top: 0;
   padding-top: 16px;
   padding-left: 18px;
@@ -725,11 +725,6 @@
   background-color: #FAFAFA;
 }
 
-.faqv2.expandable .faqv2-content.open + .faqv2-header,
-.faqv2.expandable .faqv2-header + .faqv2-content.open {
-  background-color: #FAFAFA;
-}
-
-.faqv2.expandable .faqv2-toggle:has(.faqv2-content.open) {
+.faqv2.expandable:not(.longform) .faqv2-toggle:has(.faqv2-content.open) {
   background-color: #FAFAFA;
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -490,6 +490,7 @@
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.16);
     margin-top: 25px;
     background: rgba(255, 255, 255, 0.65);
+    max-height: 1300px;
   }
 
   .faqv2.longform .faqv2-longform-header-container {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -694,6 +694,10 @@
   max-height: 0;
 }
 
+.faqv2.expandable:not(.longform) .faqv2-content {
+  padding-left: 21px;
+}
+
 .faqv2.expandable:not(.longform) .faqv2-content.open {
   margin-top: 0;
   padding: 0px 30px 16px 21px;

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -205,7 +205,6 @@
 .faqv2-accordion.expandable.header-accordion.rounded-corners {
   border-radius: 8px 8px 0 0;
   background: #FAFAFA;
-  box-shadow: none;
   box-shadow: 0px 4px 6px 0px rgba(0, 0, 0, 0.1);
 }
 
@@ -466,6 +465,16 @@
 
   .faqv2.expandable.longform .faqv2-wrapper {
     box-shadow: unset;
+  }
+
+  .faqv2.expandable.longform .faqv2-accordions-col {
+    opacity: 1;
+  }
+  
+  .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:first-child,
+  .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper,
+  .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:last-child {
+    box-shadow: none;
   }
 
   .faqv2 {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -184,7 +184,7 @@
   content: '';
   position: absolute;
   bottom: 0;
-  left: 5%;
+  left: 3%;
   right: 5%;
   width: 90%;
   border-bottom: 1px solid #8F8F8F;

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -489,6 +489,7 @@
     border-radius: 16px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.16);
     margin-top: 25px;
+    background: rgba(255, 255, 255, 0.65);
   }
 
   .faqv2.longform .faqv2-longform-header-container {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -125,6 +125,11 @@
 
 .section:has(.faqv2.expandable) picture.section-background {
   height: 750px;
+  opacity: 0.5;
+}
+
+.faqv2.expandable.longform .faqv2-accordions-col {
+  opacity: 0.8;
 }
 
 .faqv2.expandable.longform .faqv2-accordions-col .faqv2-wrapper:first-child {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -21,6 +21,10 @@
   position: relative;
 }
 
+.faqv2.expandable.longform .faqv2-wrapper .faqv2-toggle {
+  padding-left: 24px;
+}
+
 .faqv2.expandable {
   margin-bottom: 64px;
 }
@@ -406,6 +410,10 @@
   display: none;
 }
 
+.faqv2.longform.expandable .faqv2-header {
+  padding-left: 0;
+}
+
 @media (min-width: 400px) {
   .faqv2-header {
     font-size: var(--body-font-size-m);
@@ -494,6 +502,18 @@
 @media (min-width: 900px) {
   .faqv2 .has-background picture img {
     opacity: 0.5;
+  }
+
+  .faqv2.expandable.longform .faqv2-header {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--color-gray-800);
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-right: 16px;
+    padding-left: 0;
   }
 
   .section:has(.faqv2.expandable) picture.section-background {
@@ -656,18 +676,6 @@
 
 .faqv2.expandable.longform .faqv2-toggle:not(:last-child) {
   border-bottom: 1px solid #8F8F8F;
-}
-
-.faqv2.expandable.longform .faqv2-header {
-  font-size: 22px;
-  font-weight: 700;
-  color: var(--color-gray-800);
-  cursor: pointer;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding-right: 16px;
-  padding-left: 0;
 }
 
 .faqv2.expandable .faqv2-toggle:not(:last-child) {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -463,6 +463,10 @@
     opacity: 0.5;
   }
 
+  .section:has(.faqv2.expandable) picture.section-background {
+    opacity: 1;
+  }
+
   .faqv2.expandable.longform .faqv2-wrapper {
     box-shadow: unset;
   }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -706,6 +706,7 @@
   justify-content: space-between;
   align-items: center;
   padding-right: 16px;
+  padding-left: 21px;
 }
 
 .faqv2.expandable .faqv2-content {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -33,10 +33,6 @@
   position: relative;
 }
 
-.faqv2.expandable:not(.longform) .faqv2-toggle {
-  padding: 12px 0 0;
-}
-
 .faqv2.expandable:not(.longform) .faqv2-wrapper::before {
   content: '';
   position: absolute;
@@ -689,10 +685,6 @@
   margin-bottom: 16px;
 }
 
-.faqv2.expandable .faqv2-toggle {
-  padding: 16px 0;
-}
-
 .faqv2.expandable .faqv2-toggle:not(:last-child) {
   border-bottom: 1px solid #8F8F8F;
 }
@@ -705,23 +697,22 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-right: 16px;
-  padding-left: 21px;
+  padding: 24px 16px 24px 21px;
 }
 
 .faqv2.expandable .faqv2-content {
   overflow: hidden;
   transition: max-height 300ms ease-out;
   margin-top: 0;
-  padding-top: 16px;
-  padding-left: 18px;
+  padding-top: 0;
+  padding-left: 21px;
   padding-right: 30px;
   max-height: 0;
 }
 
 .faqv2.expandable:not(.longform) .faqv2-content.open {
   margin-top: 0;
-  padding: 16px 30px 16px 18px;
+  padding: 0px 30px 16px 18px;
   background-color: #FAFAFA;
 }
 

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -722,4 +722,14 @@
   padding-top: 16px;
   padding-left: 18px;
   padding-right: 30px;
+  background-color: #FAFAFA;
+}
+
+.faqv2.expandable .faqv2-content.open + .faqv2-header,
+.faqv2.expandable .faqv2-header + .faqv2-content.open {
+  background-color: #FAFAFA;
+}
+
+.faqv2.expandable .faqv2-toggle:has(.faqv2-content.open) {
+  background-color: #FAFAFA;
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -484,8 +484,6 @@
     flex-direction: row;
     align-items: center;
     width: 100%;
-    padding: 30px 10px;
-    max-width: 90%;
     border-radius: 16px;
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.16);
     margin-top: 25px;

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -124,7 +124,7 @@
 }
 
 .section:has(.faqv2.expandable) picture.section-background {
-  height: 750px;
+  height: 100%;
   opacity: 0.5;
 }
 

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -47,6 +47,15 @@
   justify-content: center;
 }
 
+.faqv2.expandable.longform .faqv2-content {
+  padding-left: 18px;
+  padding-right: 30px;
+}
+
+.faqv2.expandable.longform .faqv2-content.open {
+  padding-right: 30px;
+}
+
 .faqv2.bold {
   width: 97%;
 }
@@ -456,6 +465,21 @@
     padding-left: 32px;
     padding-right: 32px;
   }
+  .faqv2.expandable.longform .faqv2-content {
+    overflow: hidden;
+    transition: max-height 300ms ease-out;
+    margin-top: 0;
+    padding-top: 16px;
+    padding-left: 18px;
+    padding-right: 60px;
+  }
+  
+  .faqv2.expandable.longform .faqv2-content.open {
+    margin-top: 0;
+    padding-top: 16px;
+    padding-left: 18px;
+    padding-right: 60px;
+  }
 }
 
 @media (min-width: 900px) {
@@ -639,20 +663,4 @@
   align-items: center;
   padding-right: 16px;
   margin-bottom: 16px;
-}
-
-.faqv2.expandable.longform .faqv2-content {
-  overflow: hidden;
-  transition: max-height 300ms ease-out;
-  margin-top: 0;
-  padding-top: 16px;
-  padding-left: 18px;
-  padding-right: 60px;
-}
-
-.faqv2.expandable.longform .faqv2-content.open {
-  margin-top: 0;
-  padding-top: 16px;
-  padding-left: 18px;
-  padding-right: 60px;
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -696,7 +696,7 @@
 }
 
 .faqv2.expandable .faqv2-header {
-  font-size: 22px;
+  font-size: 18px;
   font-weight: 700;
   color: var(--color-gray-800);
   cursor: pointer;

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -712,7 +712,7 @@
 
 .faqv2.expandable:not(.longform) .faqv2-content.open {
   margin-top: 0;
-  padding: 0px 30px 16px 18px;
+  padding: 0px 30px 16px 21px;
   background-color: #FAFAFA;
 }
 

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -185,7 +185,8 @@
   content: '';
   position: absolute;
   bottom: 0;
-  width: 100%;
+  width: calc(100% - 48px);
+  left: 24px;
   border-bottom: 1px solid #8F8F8F;
 }
 
@@ -499,6 +500,15 @@
 @media (min-width: 900px) {
   .faqv2 .has-background picture img {
     opacity: 0.5;
+  }
+
+  .faqv2.expandable.longform .faqv2-wrapper:not(:last-child)::after {
+    width: 100%;
+    left: unset;
+  }
+
+  .faqv2.expandable.longform .faqv2-wrapper .faqv2-toggle {
+    padding-left: 0;
   }
 
   .faqv2.expandable.longform .faqv2-header {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -682,7 +682,6 @@
   justify-content: space-between;
   align-items: center;
   padding-right: 16px;
-  margin-bottom: 16px;
 }
 
 .faqv2.expandable .faqv2-toggle:not(:last-child) {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -490,7 +490,7 @@
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.16);
     margin-top: 25px;
     background: rgba(255, 255, 255, 0.65);
-    max-height: 1300px;
+    max-width: 1300px;
   }
 
   .faqv2.longform .faqv2-longform-header-container {

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -413,6 +413,7 @@
 
 .faqv2.longform.expandable .faqv2-header {
   padding-left: 0;
+  padding-top: 32px;
 }
 
 @media (min-width: 400px) {
@@ -654,7 +655,6 @@
 }
 
 @media (min-width: 1280px) {
-
   .faqv2 .faqv2-header {
     font-size: var(--body-font-size-l);
   }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -272,6 +272,10 @@
   opacity: 1;
 }
 
+.faqv2.longform .faqv2-accordion.expandable.sub-header-accordion.collapsed::before {
+  opacity: 0;
+}
+
 .faqv2-accordion.expandable.sub-header-accordion.collapsed::after {
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -503,6 +503,10 @@
     opacity: 0.5;
   }
 
+  .faqv2.longform.expandable .faqv2-header {
+    padding-top: 24px;
+  }
+
   .faqv2.expandable.longform .faqv2-wrapper:not(:last-child)::after {
     width: 100%;
     left: unset;

--- a/express/code/blocks/faqv2/faqv2.css
+++ b/express/code/blocks/faqv2/faqv2.css
@@ -673,3 +673,40 @@
   padding-right: 16px;
   margin-bottom: 16px;
 }
+
+.faqv2.expandable .faqv2-toggle {
+  padding: 16px 0;
+}
+
+.faqv2.expandable .faqv2-toggle:not(:last-child) {
+  border-bottom: 1px solid #8F8F8F;
+}
+
+.faqv2.expandable .faqv2-header {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-gray-800);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-right: 16px;
+  margin-bottom: 16px;
+}
+
+.faqv2.expandable .faqv2-content {
+  overflow: hidden;
+  transition: max-height 300ms ease-out;
+  margin-top: 0;
+  padding-top: 16px;
+  padding-left: 18px;
+  padding-right: 30px;
+  max-height: 0;
+}
+
+.faqv2.expandable .faqv2-content.open {
+  margin-top: 0;
+  padding-top: 16px;
+  padding-left: 18px;
+  padding-right: 30px;
+}

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -48,7 +48,7 @@ function buildTableLayout(block) {
       toggle.appendChild(headerDiv);
 
       const iconElement = createTag('img', {
-        src: index === 0 ? `${config.codeRoot}/icons/minus-heavy.svg` : `${config.codeRoot}/icons/plus-heavy.svg`,
+        src: `${config.codeRoot}/icons/plus-heavy.svg`,
         alt: 'toggle-icon',
         class: 'toggle-icon',
       });
@@ -59,16 +59,8 @@ function buildTableLayout(block) {
       toggle.appendChild(content);
 
       // Set initial state
-      if (index === 0) {
-        content.classList.add('open');
-        // Use requestAnimationFrame to ensure content is rendered
-        requestAnimationFrame(() => {
-          content.style.maxHeight = `${content.scrollHeight}px`;
-        });
-      } else {
-        content.style.maxHeight = '0';
-        content.style.overflow = 'hidden';
-      }
+      content.style.maxHeight = '0';
+      content.style.overflow = 'hidden';
 
       headerDiv.addEventListener('click', () => {
         const isOpen = content.classList.contains('open');
@@ -122,7 +114,7 @@ function buildTableLayout(block) {
       headerAccordion.appendChild(headerDiv);
 
       const iconElement = createTag('img', {
-        src: index === 0 ? `${config.codeRoot}/icons/minus-heavy.svg` : `${config.codeRoot}/icons/plus-heavy.svg`,
+        src: `${config.codeRoot}/icons/plus-heavy.svg`,
         alt: 'toggle-icon',
         class: 'toggle-icon',
       });

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -99,19 +99,13 @@ function buildTableLayout(block) {
         }
       });
     } else {
-      // Original non-longform code
-      const headerAccordion = createTag('div', {
-        class: 'faqv2-accordion expandable header-accordion',
-        'aria-expanded': index === 0,
-        'aria-label': 'Expand quotes',
-        role: 'button',
-        tabIndex: 0,
-      });
-      rowWrapper.appendChild(headerAccordion);
+      // Non-longform version using the same structure
+      const toggle = createTag('div', { class: 'faqv2-toggle' });
+      rowWrapper.appendChild(toggle);
 
-      const headerDiv = createTag('h3', { class: 'faqv2-header expandable' });
+      const headerDiv = createTag('h3', { class: 'faqv2-header' });
       headerDiv.innerHTML = header;
-      headerAccordion.appendChild(headerDiv);
+      toggle.appendChild(headerDiv);
 
       const iconElement = createTag('img', {
         src: `${config.codeRoot}/icons/plus-heavy.svg`,
@@ -120,46 +114,48 @@ function buildTableLayout(block) {
       });
       headerDiv.appendChild(iconElement);
 
-      const subHeaderAccordion = createTag('div', {
-        class: `faqv2-accordion expandable sub-header-accordion${index === 0 ? ' open' : ''}`,
-      });
-      rowWrapper.appendChild(subHeaderAccordion);
-      const subHeaderDiv = createTag('div', { class: 'faqv2-sub-header expandable' });
-      subHeaderDiv.innerHTML = subHeader;
-      subHeaderAccordion.appendChild(subHeaderDiv);
+      const content = createTag('div', { class: 'faqv2-content' });
+      content.innerHTML = subHeader;
+      toggle.appendChild(content);
 
-      if (index === 0 && !isLongFormVariant) {
-        headerAccordion.classList.add('rounded-corners');
-      }
+      // Set initial state
+      content.style.maxHeight = '0';
+      content.style.overflow = 'hidden';
 
       headerDiv.addEventListener('click', () => {
-        const allSubHeaders = block.querySelectorAll('.sub-header-accordion');
-        const allHeaders = block.querySelectorAll('.header-accordion');
-        const allIcons = block.querySelectorAll('.toggle-icon');
+        const isOpen = content.classList.contains('open');
 
-        allSubHeaders.forEach((accordion, idx) => {
-          if (accordion !== subHeaderAccordion) {
-            accordion.classList.remove('open');
-            if (!isLongFormVariant) {
-              allHeaders[idx].classList.remove('rounded-corners');
-            }
+        // Close all other accordions first
+        const allContents = block.querySelectorAll('.faqv2-content');
+        const allIcons = block.querySelectorAll('.toggle-icon');
+        allContents.forEach((otherContent, idx) => {
+          if (otherContent !== content && otherContent.classList.contains('open')) {
+            otherContent.style.maxHeight = `${otherContent.scrollHeight}px`;
+            otherContent.offsetHeight; // Force reflow
+            otherContent.classList.remove('open');
+            otherContent.style.maxHeight = '0';
             allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
           }
         });
 
-        const isOpen = subHeaderAccordion.classList.toggle('open');
-        if (!isLongFormVariant) {
-          headerAccordion.classList.toggle('rounded-corners', isOpen);
-        }
-        iconElement.src = isOpen
-          ? `${config.codeRoot}/icons/minus-heavy.svg`
-          : `${config.codeRoot}/icons/plus-heavy.svg`;
-      });
-
-      headerAccordion.addEventListener('keydown', (event) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          headerDiv.click();
+        if (!isOpen) {
+          // Set height to 0 first
+          content.style.maxHeight = '0';
+          // Force a reflow
+          content.offsetHeight;
+          // Add open class and set to actual height
+          content.classList.add('open');
+          content.style.maxHeight = `${content.scrollHeight}px`;
+          iconElement.src = `${config.codeRoot}/icons/minus-heavy.svg`;
+        } else {
+          // Set to actual height first
+          content.style.maxHeight = `${content.scrollHeight}px`;
+          // Force a reflow
+          content.offsetHeight;
+          // Remove open class and set to 0
+          content.classList.remove('open');
+          content.style.maxHeight = '0';
+          iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
         }
       });
     }

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -65,11 +65,11 @@ function buildTableLayout(block) {
     subHeaderAccordion.appendChild(subHeaderDiv);
 
     headerDiv.addEventListener('click', () => {
-      const isCollapsed = subHeaderAccordion.classList.toggle('collapsed');
+      const isOpen = subHeaderAccordion.classList.toggle('open');
       if (!isLongFormVariant) {
-        headerAccordion.classList.toggle('rounded-corners', isCollapsed);
+        headerAccordion.classList.toggle('rounded-corners', isOpen);
       }
-      iconElement.src = isCollapsed
+      iconElement.src = isOpen
         ? `${config.codeRoot}/icons/minus-heavy.svg`
         : `${config.codeRoot}/icons/plus-heavy.svg`;
     });
@@ -113,7 +113,7 @@ async function buildOriginalLayout(block) {
     const accordion = createTag('div', { class: 'faqv2-accordion' });
 
     if (index >= visibleCount) {
-      accordion.classList.add('collapsed');
+      accordion.classList.add('open');
     }
 
     block.append(accordion);
@@ -147,7 +147,7 @@ async function buildOriginalLayout(block) {
     const hiddenItems = block.querySelectorAll('.faqv2-accordion');
     hiddenItems.forEach((item, index) => {
       if (index >= visibleCount) {
-        item.classList.toggle('collapsed');
+        item.classList.toggle('open');
       }
     });
 

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -65,6 +65,21 @@ function buildTableLayout(block) {
     subHeaderAccordion.appendChild(subHeaderDiv);
 
     headerDiv.addEventListener('click', () => {
+      // Close all other open accordions first
+      const allSubHeaders = block.querySelectorAll('.sub-header-accordion');
+      const allHeaders = block.querySelectorAll('.header-accordion');
+      const allIcons = block.querySelectorAll('.toggle-icon');
+
+      allSubHeaders.forEach((accordion, idx) => {
+        if (accordion !== subHeaderAccordion) {
+          accordion.classList.remove('open');
+          if (!isLongFormVariant) {
+            allHeaders[idx].classList.remove('rounded-corners');
+          }
+          allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
+        }
+      });
+
       const isOpen = subHeaderAccordion.classList.toggle('open');
       if (!isLongFormVariant) {
         headerAccordion.classList.toggle('rounded-corners', isOpen);

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -79,20 +79,17 @@ function buildTableLayout(block) {
         });
 
         if (!isOpen) {
-          // Set height to 0 first
+          // Calculate height before adding open class
+          content.style.maxHeight = 'none';
+          const height = content.scrollHeight;
           content.style.maxHeight = '0';
-          // Force a reflow
-          content.offsetHeight;
-          // Add open class and set to actual height
+          content.offsetHeight; // Force reflow
           content.classList.add('open');
-          content.style.maxHeight = `${content.scrollHeight}px`;
+          content.style.maxHeight = `${height}px`;
           iconElement.src = `${config.codeRoot}/icons/minus-heavy.svg`;
         } else {
-          // Set to actual height first
           content.style.maxHeight = `${content.scrollHeight}px`;
-          // Force a reflow
-          content.offsetHeight;
-          // Remove open class and set to 0
+          content.offsetHeight; // Force reflow
           content.classList.remove('open');
           content.style.maxHeight = '0';
           iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
@@ -139,20 +136,17 @@ function buildTableLayout(block) {
         });
 
         if (!isOpen) {
-          // Set height to 0 first
+          // Calculate height before adding open class
+          content.style.maxHeight = 'none';
+          const height = content.scrollHeight;
           content.style.maxHeight = '0';
-          // Force a reflow
-          content.offsetHeight;
-          // Add open class and set to actual height
+          content.offsetHeight; // Force reflow
           content.classList.add('open');
-          content.style.maxHeight = `${content.scrollHeight}px`;
+          content.style.maxHeight = `${height}px`;
           iconElement.src = `${config.codeRoot}/icons/minus-heavy.svg`;
         } else {
-          // Set to actual height first
           content.style.maxHeight = `${content.scrollHeight}px`;
-          // Force a reflow
-          content.offsetHeight;
-          // Remove open class and set to 0
+          content.offsetHeight; // Force reflow
           content.classList.remove('open');
           content.style.maxHeight = '0';
           iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -95,6 +95,13 @@ function buildTableLayout(block) {
           iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
         }
       });
+
+      // Open first accordion by default after a small delay
+      if (index === 0) {
+        setTimeout(() => {
+          headerDiv.click();
+        }, 100);
+      }
     } else {
       // Non-longform version using the same structure
       const toggle = createTag('div', { class: 'faqv2-toggle' });

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -34,13 +34,13 @@ function buildTableLayout(block) {
     };
   });
 
-  collapsibleRows.forEach(({ header, subHeader }) => {
+  collapsibleRows.forEach(({ header, subHeader }, index) => {
     const rowWrapper = createTag('div', { class: 'faqv2-wrapper' });
     container.appendChild(rowWrapper);
 
     const headerAccordion = createTag('div', {
       class: 'faqv2-accordion expandable header-accordion',
-      'aria-expanded': false,
+      'aria-expanded': index === 0,
       'aria-label': 'Expand quotes',
       role: 'button',
       tabIndex: 0,
@@ -52,17 +52,23 @@ function buildTableLayout(block) {
     headerAccordion.appendChild(headerDiv);
 
     const iconElement = createTag('img', {
-      src: `${config.codeRoot}/icons/plus-heavy.svg`,
+      src: index === 0 ? `${config.codeRoot}/icons/minus-heavy.svg` : `${config.codeRoot}/icons/plus-heavy.svg`,
       alt: 'toggle-icon',
       class: 'toggle-icon',
     });
     headerDiv.appendChild(iconElement);
 
-    const subHeaderAccordion = createTag('div', { class: 'faqv2-accordion expandable sub-header-accordion' });
+    const subHeaderAccordion = createTag('div', {
+      class: `faqv2-accordion expandable sub-header-accordion${index === 0 ? ' open' : ''}`,
+    });
     rowWrapper.appendChild(subHeaderAccordion);
     const subHeaderDiv = createTag('div', { class: 'faqv2-sub-header expandable' });
     subHeaderDiv.innerHTML = subHeader;
     subHeaderAccordion.appendChild(subHeaderDiv);
+
+    if (index === 0 && !isLongFormVariant) {
+      headerAccordion.classList.add('rounded-corners');
+    }
 
     headerDiv.addEventListener('click', () => {
       // Close all other open accordions first

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -152,6 +152,13 @@ function buildTableLayout(block) {
           iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
         }
       });
+
+      // Open first accordion by default after a small delay
+      if (index === 0) {
+        setTimeout(() => {
+          headerDiv.click();
+        }, 100);
+      }
     }
   });
 

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -67,6 +67,7 @@ function buildTableLayout(block) {
         });
       } else {
         content.style.maxHeight = '0';
+        content.style.overflow = 'hidden';
       }
 
       headerDiv.addEventListener('click', () => {

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -38,70 +38,140 @@ function buildTableLayout(block) {
     const rowWrapper = createTag('div', { class: 'faqv2-wrapper' });
     container.appendChild(rowWrapper);
 
-    const headerAccordion = createTag('div', {
-      class: 'faqv2-accordion expandable header-accordion',
-      'aria-expanded': index === 0,
-      'aria-label': 'Expand quotes',
-      role: 'button',
-      tabIndex: 0,
-    });
-    rowWrapper.appendChild(headerAccordion);
+    if (isLongFormVariant) {
+      // Simple toggle for longform
+      const toggle = createTag('div', { class: 'faqv2-toggle' });
+      rowWrapper.appendChild(toggle);
 
-    const headerDiv = createTag('h3', { class: 'faqv2-header expandable' });
-    headerDiv.innerHTML = header;
-    headerAccordion.appendChild(headerDiv);
+      const headerDiv = createTag('h3', { class: 'faqv2-header' });
+      headerDiv.innerHTML = header;
+      toggle.appendChild(headerDiv);
 
-    const iconElement = createTag('img', {
-      src: index === 0 ? `${config.codeRoot}/icons/minus-heavy.svg` : `${config.codeRoot}/icons/plus-heavy.svg`,
-      alt: 'toggle-icon',
-      class: 'toggle-icon',
-    });
-    headerDiv.appendChild(iconElement);
+      const iconElement = createTag('img', {
+        src: index === 0 ? `${config.codeRoot}/icons/minus-heavy.svg` : `${config.codeRoot}/icons/plus-heavy.svg`,
+        alt: 'toggle-icon',
+        class: 'toggle-icon',
+      });
+      headerDiv.appendChild(iconElement);
 
-    const subHeaderAccordion = createTag('div', {
-      class: `faqv2-accordion expandable sub-header-accordion${index === 0 ? ' open' : ''}`,
-    });
-    rowWrapper.appendChild(subHeaderAccordion);
-    const subHeaderDiv = createTag('div', { class: 'faqv2-sub-header expandable' });
-    subHeaderDiv.innerHTML = subHeader;
-    subHeaderAccordion.appendChild(subHeaderDiv);
+      const content = createTag('div', { class: 'faqv2-content' });
+      content.innerHTML = subHeader;
+      toggle.appendChild(content);
 
-    if (index === 0 && !isLongFormVariant) {
-      headerAccordion.classList.add('rounded-corners');
-    }
+      // Set initial state
+      if (index === 0) {
+        content.classList.add('open');
+        // Use requestAnimationFrame to ensure content is rendered
+        requestAnimationFrame(() => {
+          content.style.maxHeight = `${content.scrollHeight}px`;
+        });
+      } else {
+        content.style.maxHeight = '0';
+      }
 
-    headerDiv.addEventListener('click', () => {
-      // Close all other open accordions first
-      const allSubHeaders = block.querySelectorAll('.sub-header-accordion');
-      const allHeaders = block.querySelectorAll('.header-accordion');
-      const allIcons = block.querySelectorAll('.toggle-icon');
+      headerDiv.addEventListener('click', () => {
+        const isOpen = content.classList.contains('open');
 
-      allSubHeaders.forEach((accordion, idx) => {
-        if (accordion !== subHeaderAccordion) {
-          accordion.classList.remove('open');
-          if (!isLongFormVariant) {
-            allHeaders[idx].classList.remove('rounded-corners');
+        // Close all other accordions first
+        const allContents = block.querySelectorAll('.faqv2-content');
+        const allIcons = block.querySelectorAll('.toggle-icon');
+        allContents.forEach((otherContent, idx) => {
+          if (otherContent !== content && otherContent.classList.contains('open')) {
+            otherContent.style.maxHeight = `${otherContent.scrollHeight}px`;
+            otherContent.offsetHeight; // Force reflow
+            otherContent.classList.remove('open');
+            otherContent.style.maxHeight = '0';
+            allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
           }
-          allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
+        });
+
+        if (!isOpen) {
+          // Set height to 0 first
+          content.style.maxHeight = '0';
+          // Force a reflow
+          content.offsetHeight;
+          // Add open class and set to actual height
+          content.classList.add('open');
+          content.style.maxHeight = `${content.scrollHeight}px`;
+          iconElement.src = `${config.codeRoot}/icons/minus-heavy.svg`;
+        } else {
+          // Set to actual height first
+          content.style.maxHeight = `${content.scrollHeight}px`;
+          // Force a reflow
+          content.offsetHeight;
+          // Remove open class and set to 0
+          content.classList.remove('open');
+          content.style.maxHeight = '0';
+          iconElement.src = `${config.codeRoot}/icons/plus-heavy.svg`;
         }
       });
+    } else {
+      // Original non-longform code
+      const headerAccordion = createTag('div', {
+        class: 'faqv2-accordion expandable header-accordion',
+        'aria-expanded': index === 0,
+        'aria-label': 'Expand quotes',
+        role: 'button',
+        tabIndex: 0,
+      });
+      rowWrapper.appendChild(headerAccordion);
 
-      const isOpen = subHeaderAccordion.classList.toggle('open');
-      if (!isLongFormVariant) {
-        headerAccordion.classList.toggle('rounded-corners', isOpen);
-      }
-      iconElement.src = isOpen
-        ? `${config.codeRoot}/icons/minus-heavy.svg`
-        : `${config.codeRoot}/icons/plus-heavy.svg`;
-    });
+      const headerDiv = createTag('h3', { class: 'faqv2-header expandable' });
+      headerDiv.innerHTML = header;
+      headerAccordion.appendChild(headerDiv);
 
-    headerAccordion.addEventListener('keydown', (event) => {
-      if (event.key === 'Enter' || event.key === ' ') {
-        event.preventDefault();
-        headerDiv.click();
+      const iconElement = createTag('img', {
+        src: index === 0 ? `${config.codeRoot}/icons/minus-heavy.svg` : `${config.codeRoot}/icons/plus-heavy.svg`,
+        alt: 'toggle-icon',
+        class: 'toggle-icon',
+      });
+      headerDiv.appendChild(iconElement);
+
+      const subHeaderAccordion = createTag('div', {
+        class: `faqv2-accordion expandable sub-header-accordion${index === 0 ? ' open' : ''}`,
+      });
+      rowWrapper.appendChild(subHeaderAccordion);
+      const subHeaderDiv = createTag('div', { class: 'faqv2-sub-header expandable' });
+      subHeaderDiv.innerHTML = subHeader;
+      subHeaderAccordion.appendChild(subHeaderDiv);
+
+      if (index === 0 && !isLongFormVariant) {
+        headerAccordion.classList.add('rounded-corners');
       }
-    });
+
+      headerDiv.addEventListener('click', () => {
+        const allSubHeaders = block.querySelectorAll('.sub-header-accordion');
+        const allHeaders = block.querySelectorAll('.header-accordion');
+        const allIcons = block.querySelectorAll('.toggle-icon');
+
+        allSubHeaders.forEach((accordion, idx) => {
+          if (accordion !== subHeaderAccordion) {
+            accordion.classList.remove('open');
+            if (!isLongFormVariant) {
+              allHeaders[idx].classList.remove('rounded-corners');
+            }
+            allIcons[idx].src = `${config.codeRoot}/icons/plus-heavy.svg`;
+          }
+        });
+
+        const isOpen = subHeaderAccordion.classList.toggle('open');
+        if (!isLongFormVariant) {
+          headerAccordion.classList.toggle('rounded-corners', isOpen);
+        }
+        iconElement.src = isOpen
+          ? `${config.codeRoot}/icons/minus-heavy.svg`
+          : `${config.codeRoot}/icons/plus-heavy.svg`;
+      });
+
+      headerAccordion.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          headerDiv.click();
+        }
+      });
+    }
   });
+
   block.replaceChildren(...parentContainer.childNodes);
 }
 

--- a/express/code/blocks/faqv2/faqv2.js
+++ b/express/code/blocks/faqv2/faqv2.js
@@ -29,8 +29,8 @@ function buildTableLayout(block) {
   const collapsibleRows = rows.map((row) => {
     const cells = [...row.children];
     return {
-      header: cells[0]?.textContent.trim(),
-      subHeader: cells[1]?.textContent,
+      header: cells[0]?.innerHTML.trim(),
+      subHeader: cells[1]?.innerHTML,
     };
   });
 
@@ -48,7 +48,7 @@ function buildTableLayout(block) {
     rowWrapper.appendChild(headerAccordion);
 
     const headerDiv = createTag('h3', { class: 'faqv2-header expandable' });
-    headerDiv.textContent = header;
+    headerDiv.innerHTML = header;
     headerAccordion.appendChild(headerDiv);
 
     const iconElement = createTag('img', {
@@ -61,7 +61,7 @@ function buildTableLayout(block) {
     const subHeaderAccordion = createTag('div', { class: 'faqv2-accordion expandable sub-header-accordion' });
     rowWrapper.appendChild(subHeaderAccordion);
     const subHeaderDiv = createTag('div', { class: 'faqv2-sub-header expandable' });
-    subHeaderDiv.textContent = subHeader;
+    subHeaderDiv.innerHTML = subHeader;
     subHeaderAccordion.appendChild(subHeaderDiv);
 
     headerDiv.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.
* Ensure the long form variant does not have a colored left side when expanded
* Ensure the long form variant does not have a box shadow
* Reduce the visibility of the diffuse background colors to make the effect more sublte

---

## Jira Ticket

Resolves: [MWPW-172947](https://jira.corp.adobe.com/browse/MWPW-172947)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/drafts/jsandlan/milo-longform-v2 |
| **After**   | https://long-form-faq-bug--express-milo--adobecom.aem.page/drafts/jsandlan/milo-longform-v2?martech=off |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
1. Load https://long-form-faq-bug--express-milo--adobecom.aem.page/drafts/jsandlan/milo-longform-v2?martech=off 
2. Click on any of the title text on the right side of the viewport. The relevant block is at the top of the page.
3. In the Before - you will see a box-shadow, an underline,  and a colored left border for the expandable sections in the block at the top of the page (the longform variant) and the background image bleeds through too much.
4. In the After - you should see that the box-shadow and underline have disappeared from each individual section, that the colored left border is gone when you expand each section, and a more subtle background color bleed through.
- What to expect **before** and **after** the change.
**Before**: 
<img width="1643" alt="Before" src="https://github.com/user-attachments/assets/c6755811-2cd0-4482-ae08-bceebfdb8ef9" />
**After**:
<img width="1581" alt="After" src="https://github.com/user-attachments/assets/48b7de22-3aed-44da-904c-7043fc00c4df" />

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- N/A since this is a new block I don't believe it's being used anywhere.

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
