### PR TITLE
[MWPW-171815] updated share icon wrapper to be sibling instead of child of <a>

### DIFF
--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -490,7 +490,7 @@ function renderHoverWrapper(template) {
 
   btnContainer.append(cta);
   btnContainer.append(ctaLink);
-  btnContainer.append(shareWrapper); // Append as sibling instead of inside ctaLink
+  btnContainer.append(shareWrapper);
 
   btnContainer.addEventListener('mouseenter', enterHandler);
   btnContainer.addEventListener('mouseleave', leaveHandler);

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -491,7 +491,7 @@ function renderHoverWrapper(template) {
   btnContainer.append(cta);
   btnContainer.append(ctaLink);
   btnContainer.append(shareWrapper); // Append as sibling instead of inside ctaLink
-  
+
   btnContainer.addEventListener('mouseenter', enterHandler);
   btnContainer.addEventListener('mouseleave', leaveHandler);
 

--- a/express/code/blocks/template-x/template-rendering.js
+++ b/express/code/blocks/template-x/template-rendering.js
@@ -420,8 +420,6 @@ function renderMediaWrapper(template) {
     e.stopPropagation();
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
-      const shareWrapper = renderShareWrapper(templateInfo);
-      mediaWrapper.append(shareWrapper);
     }
     renderedMedia.hover();
     currentHoveredElement?.classList.remove('singleton-hover');
@@ -439,8 +437,6 @@ function renderMediaWrapper(template) {
     e.stopPropagation();
     if (!renderedMedia) {
       renderedMedia = await renderRotatingMedias(mediaWrapper, template.pages, templateInfo);
-      const shareWrapper = renderShareWrapper(templateInfo);
-      mediaWrapper.append(shareWrapper);
       renderedMedia.hover();
     }
     currentHoveredElement?.classList.remove('singleton-hover');
@@ -481,8 +477,21 @@ function renderHoverWrapper(template) {
   cta.setAttribute('aria-label', `${editThisTemplate} ${getTemplateTitle(template)}`);
   ctaLink.append(mediaWrapper);
 
+  // Create shareWrapper separately
+  const templateTitle = getTemplateTitle(template);
+  const { branchUrl } = template.customLinks;
+  const templateInfo = {
+    templateTitle,
+    branchUrl,
+    renditionLinkHref: extractRenditionLinkHref(template),
+    componentLinkHref: extractComponentLinkHref(template),
+  };
+  const shareWrapper = renderShareWrapper(templateInfo);
+
   btnContainer.append(cta);
   btnContainer.append(ctaLink);
+  btnContainer.append(shareWrapper); // Append as sibling instead of inside ctaLink
+  
   btnContainer.addEventListener('mouseenter', enterHandler);
   btnContainer.addEventListener('mouseleave', leaveHandler);
 

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2307,7 +2307,7 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   padding: 2px 6px 4px;
 }
 
-.template-x .template .button-container .media-wrapper .icon-share-arrow {
+.template-x .template .button-container .icon-share-arrow {
   cursor: pointer;
   pointer-events: auto;
   width: 16px;
@@ -2317,15 +2317,30 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   overflow: visible;
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper {
+.template-x .template .button-container .share-icon-wrapper {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  top: 16px;
+  right: 16px;
   border-radius: 50%;
   height: 20px;
+  opacity: 1;
+  pointer-events: initial;
+  float: right;
+  position: absolute;
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip {
+.template-x.horizontal .template .button-container > .share-icon-wrapper {
+  top: 12px;
+  right: 12px;
+}
+
+
+.template-x.horizontal.mini .template .button-container > .share-icon-wrapper {
+  top: 8px;
+  right: 8px;
+}
+
+.template-x .template .button-container .share-icon-wrapper .shared-tooltip {
   visibility: hidden;
   position: absolute;
   display: flex;
@@ -2343,12 +2358,22 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   font-size: var(--body-font-size-s);
 }
 
-.template-x.horizontal .template:nth-last-of-type(2) .button-container .media-wrapper .share-icon-wrapper .shared-tooltip {
+.template-x .template .button-container .share-icon-wrapper .icon-share-arrow {
+  cursor: pointer;
+  pointer-events: auto;
+  width: 16px;
+  height: 16px;
+  padding: 4px;
+  background-color: white;
+  overflow: visible;
+}
+
+.template-x.horizontal .template:nth-last-of-type(2) .button-container .share-icon-wrapper .shared-tooltip {
   left: unset;
   right: calc(100% + 12px);
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip .icon-checkmark-green {
+.template-x .template .button-container .share-icon-wrapper .shared-tooltip .icon-checkmark-green {
   width: 10px;
   height: 10px;
   border-radius: 30px;
@@ -2356,16 +2381,16 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   padding: 2px;
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip.display-tooltip {
+.template-x .template .button-container .share-icon-wrapper .shared-tooltip.display-tooltip {
   visibility: visible;
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip.flipped {
+.template-x .template .button-container .share-icon-wrapper .shared-tooltip.flipped {
   left: unset;
   right: calc(100% + 12px);
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip::after {
+.template-x .template .button-container .share-icon-wrapper .shared-tooltip::after {
   content: " ";
   position: absolute;
   top: 50%;
@@ -2376,13 +2401,13 @@ main .template-x .api-templates-toolbar .search-bar-wrapper.collapsed .search-dr
   border-color: transparent var(--background-positive-default) transparent transparent;
 }
 
-.template-x.horizontal .template:nth-last-of-type(2) .button-container .media-wrapper .share-icon-wrapper .shared-tooltip::after {
+.template-x.horizontal .template:nth-last-of-type(2) .button-container .share-icon-wrapper .shared-tooltip::after {
   right: unset;
   left: 100%;
   border-color: transparent transparent transparent var(--background-positive-default);
 }
 
-.template-x .template .button-container .media-wrapper .share-icon-wrapper .shared-tooltip.flipped::after {
+.template-x .template .button-container .share-icon-wrapper .shared-tooltip.flipped::after {
   right: unset;
   left: 100%;
   transform: rotate(180deg);
@@ -3232,3 +3257,38 @@ main .template-x.horizontal.tabbed.fullwidth .view-all-link-wrapper{
   }
  }
 
+ 
+/* .template-x .template .button-container > .share-icon-wrapper {
+  position: absolute;
+  top: 16px;  
+  right: 16px;  
+  border-radius: 50%;
+  height: 20px;
+  z-index: 2; 
+}
+
+.template-x .template .button-container .share-icon-wrapper .icon-share-arrow {
+  cursor: pointer;
+  pointer-events: auto;
+  width: 16px;
+  height: 16px;
+  padding: 4px;
+  background-color: white;
+  overflow: visible;
+}
+
+.template-x .template:hover:not(.placeholder) .button-container > .share-icon-wrapper {
+  opacity: 1;
+  pointer-events: initial;
+  float: right;
+}
+
+.template-x.horizontal .template .button-container > .share-icon-wrapper {
+  top: 12px;
+  right: 12px;
+}
+
+.template-x.horizontal.mini .template .button-container > .share-icon-wrapper {
+  top: 8px;
+  right: 8px;
+} */

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3256,39 +3256,3 @@ main .template-x.horizontal.tabbed.fullwidth .view-all-link-wrapper{
     margin: auto;
   }
  }
-
- 
-/* .template-x .template .button-container > .share-icon-wrapper {
-  position: absolute;
-  top: 16px;  
-  right: 16px;  
-  border-radius: 50%;
-  height: 20px;
-  z-index: 2; 
-}
-
-.template-x .template .button-container .share-icon-wrapper .icon-share-arrow {
-  cursor: pointer;
-  pointer-events: auto;
-  width: 16px;
-  height: 16px;
-  padding: 4px;
-  background-color: white;
-  overflow: visible;
-}
-
-.template-x .template:hover:not(.placeholder) .button-container > .share-icon-wrapper {
-  opacity: 1;
-  pointer-events: initial;
-  float: right;
-}
-
-.template-x.horizontal .template .button-container > .share-icon-wrapper {
-  top: 12px;
-  right: 12px;
-}
-
-.template-x.horizontal.mini .template .button-container > .share-icon-wrapper {
-  top: 8px;
-  right: 8px;
-} */


### PR DESCRIPTION
## Summary
Fix accessibility issue where share button is improperly nested inside a link element, causing screen readers to announce it incorrectly as "Share button link" instead of just "Share button". This resolves WCAG 4.1.2 Name, Role, Value compliance by ensuring interactive elements are not nested within other interactive elements.

---
## Jira Ticket
Resolves: [[MWPW-171815](https://jira.corp.adobe.com/browse/MWPW-171815)](https://jira.corp.adobe.com/browse/MWPW-171815)

---
## Test URLs
| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/feature/image/editor |
| **After**   | https://mwpw-171815-share-label--express-milo--adobecom.aem.page/express/feature/image/editor?
|After |  https://mwpw-171815-share-label--express-milo--adobecom.aem.page/express/templates/ |
|After |  https://mwpw-171815-share-label--express-milo--adobecom.aem.page/express/create/banner |

Additional test pages:
- express/templates
- express/create/banner
- Any page with template-x blocks (horizontal and vertical variants)

---
## Verification Steps
**Testing with Screen Reader (NVDA on Chrome/Windows):**
1. Turn on NVDA screen reader
2. Navigate to the test URL above
3. Tab through the page until reaching a template's share button
4. Listen to the screen reader announcement

**Expected before fix:**
- Screen reader announces "Share button link" (incorrect nesting)

**Expected after fix:**
- Screen reader announces "Share" button (proper semantic structure)
- Share functionality remains intact

**Manual Testing:**
1. Verify share button still functions correctly when clicked
2. Test on both horizontal and vertical template-x block variants
3. Confirm tooltip behavior remains unchanged
4. Validate HTML structure shows no nested interactive elements

---
## Potential Regressions
List any areas or URLs that could be affected by this change:
- https://mwpw-171815-share-label--express-milo--adobecom.aem.live/express/feature/image/editor?martech=off
- All Express pages containing template-x blocks with share functionality
- Template galleries and browsing pages
- Any custom implementations of template-x block variants

---
## Additional Notes
This fix addresses WCAG 4.1.2 Name, Role, Value (Level A) compliance by restructuring the HTML to prevent nesting of interactive elements (button inside link). The remediation ensures proper semantic structure while maintaining all existing functionality including share actions and visual styling.

**Affected user populations:** Users with visual impairments, limited vision, motor limitations, and cognitive disabilities who rely on assistive technologies.

**Testing recommendation:** Validate with multiple screen readers (NVDA, JAWS, VoiceOver) across different browsers to ensure consistent behavior.