### PR TITLE
[MWPW-175030] Diffing acom and aem templates API requests through query parameters

### DIFF
--- a/express/code/scripts/template-search-api-v3.js
+++ b/express/code/scripts/template-search-api-v3.js
@@ -236,8 +236,10 @@ async function fetchSearchUrl({
     'Oldest to Newest': '&orderBy=createDate',
   }[sort] || sort || '';
   const qParam = q && q !== '{{q}}' ? `&q=${q}` : '';
+  // workaround to prevent akamai prod cache pollution causing cors issues in aem envs
+  const envParam = new URL(base).host === window.location.host ? '' : '&ax-env=stage';
   const url = encodeURI(
-    `${base}?${collectionIdParam}${queryParam}${qParam}${limitParam}${startParam}${sortParam}${filterStr}`,
+    `${base}?${collectionIdParam}${queryParam}${qParam}${limitParam}${startParam}${sortParam}${filterStr}${envParam}`,
   );
 
   const langs = extractLangs(filters.locales);

--- a/express/code/scripts/template-utils.js
+++ b/express/code/scripts/template-utils.js
@@ -49,7 +49,9 @@ export function recipe2ApiQuery(recipe) {
   }
 
   params.set('queryType', 'search');
-  return { url: `${base}?${decodeURIComponent(params.toString())}`, headers };
+  // workaround to prevent akamai prod cache pollution causing cors issues in aem envs
+  const envParam = new URL(base).host === window.location.host ? '' : '&ax-env=stage';
+  return { url: `${base}?${decodeURIComponent(params.toString())}${envParam}`, headers };
 }
 
 export async function fetchResults(recipe) {


### PR DESCRIPTION
## Summary

Intentionally varying express-search-api-v3 calls based on crossing origins or not to avoid cache pollution on Akamai.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-175030

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.live/express/templates/flyer |
| **After**   | https://template-cors--express-milo--adobecom.aem.live/express/templates/flyer?martech=off |

---

## Verification Steps

- Visit https://www.adobe.com/express/templates/flyer to pollute the cache with a response missing accept-origin header
- Visit stage https://stage--express-milo--adobecom.aem.live/express/templates/flyer, where you should see template-x failed due to CORS error
- Visit dev branch link https://template-cors--express-milo--adobecom.aem.live/express/templates/flyer?martech=off, where you should see issue is gone as the API call has varied query parameters

---

## Potential Regressions

- https://template-cors--express-milo--adobecom.aem.live/express/templates/?martech=off
- https://template-cors--express-milo--adobecom.aem.live/express/create/flyer/?martech=off

