### PR TITLE
[MWPW-166953] Discover-Cards Gallery Style Leakage

### DIFF
--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -111,6 +111,11 @@ main .section .discover-cards {
 }
 .discover-cards .gallery-control {
     padding-top: 11px;
+    padding: var(--spacing-300) var(--spacing-300) 0;
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--spacing-100);
+    align-items: center;
 }
 .discover-cards.flip .gallery-control {
   padding-top: var(--spacing-500);
@@ -226,11 +231,10 @@ main .section .discover-cards {
     }
 }
 
-.gallery,
 .discover-cards.flip .gallery {
-  display: flex;
-  flex-wrap: nowrap;
-  gap: var(--spacing-300);
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 250px;
   overflow-x: scroll;
   scrollbar-width: none;
   scroll-snap-type: x mandatory;
@@ -239,45 +243,31 @@ main .section .discover-cards {
   scroll-padding: 0 var(--spacing-300);
 }
 
-.discover-cards.flip .gallery {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 250px;
-}
-
-.gallery::-webkit-scrollbar {
+.discover-cards .gallery::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 0;
     height: 0;
 }
 
-.gallery.center.gallery--all-displayed {
+.discover-cards .gallery.center.gallery--all-displayed {
     justify-content: center;
 }
 
-.gallery--item {
+.discover-cards .gallery--item {
     scroll-snap-align: start;
     width: calc(100% - 16px);
 }
 
-.gallery-control {
-    padding: var(--spacing-300) var(--spacing-300) 0;
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--spacing-100);
-    align-items: center;
-}
-
-.gallery-control.hide,
-.gallery-control .hide {
+.discover-cards .gallery-control.hide,
+.discover-cards .gallery-control .hide {
     display: none;
 }
 
-.gallery-control.loading {
+.discover-cards .gallery-control.loading {
     visibility: hidden;
 }
 
-.gallery-control button {
+.discover-cards .gallery-control button {
     all: unset;
     cursor: pointer;
     height: 2rem;
@@ -285,44 +275,20 @@ main .section .discover-cards {
     border-radius: 50px;
 }
 
-.gallery-control button:focus {
+.discover-cards .gallery-control button:focus {
     outline: revert;
 }
 
-.gallery-control button:hover:not(:disabled) circle {
+.discover-cards .gallery-control button:hover:not(:disabled) circle {
     fill: var(--color-gray-300);
 }
 
-.gallery-control button:disabled {
+.discover-cards .gallery-control button:disabled {
     cursor: auto;
 }
 
-.gallery-control button:disabled path {
+.discover-cards .gallery-control button:disabled path {
     stroke: var(--color-gray-300);
-}
-
-.gallery-control .status {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    background-color: white;
-    box-shadow: 0px 2px 8px 0px #00000029;
-    padding: var(--spacing-100) var(--spacing-300);
-    border-radius: 50px;
-    height: 32px;
-    box-sizing: border-box;
-}
-
-.gallery-control .status .dot {
-    border-radius: 50px;
-    width: 6px;
-    height: 6px;
-    background-color: #717171;
-}
-
-.gallery-control .status .dot.curr {
-    width: 30px;
-    background-color: #686DF4;
 }
 
 .discover-cards.flip .card {

--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -231,16 +231,23 @@ main .section .discover-cards {
     }
 }
 
+.discover-cards .gallery,
 .discover-cards.flip .gallery {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 250px;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--spacing-300);
   overflow-x: scroll;
   scrollbar-width: none;
   scroll-snap-type: x mandatory;
   scroll-behavior: smooth;
   padding: 0 var(--spacing-300);
   scroll-padding: 0 var(--spacing-300);
+}
+
+.discover-cards.flip .gallery {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 250px;
 }
 
 .discover-cards .gallery::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

Discover-cards have .gallery styles that can pollute the global space when other blocks using .gallery or compact-carousel are authored on the same page. This PR aims to remove those without causing any visual/functional changes.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-166953

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/create/brochure/tri-fold-new |
| **After**   | https://scoping-discover-cards-gallery--express-milo--adobecom.aem.page/express/create/brochure/tri-fold-new?martech=off |

---

## Verification Steps
- Visit the urls in stage, and you should see very large templates in template-x-carousel-toolbar block. This is caused by conflicting styles between template-x-carousel-toolbar and discover-cards.
- Visit the after url, and you should see templates being rendered properly.

---

## Potential Regressions
Pages where discover-cards are used:
- https://scoping-discover-cards-gallery--express-milo--adobecom.aem.live/express/?martech=off
- https://scoping-discover-cards-gallery--express-milo--adobecom.aem.live/express/ambassadors?martech=off
- https://scoping-discover-cards-gallery--express-milo--adobecom.aem.live/express/business/teams?martech=off
- https://scoping-discover-cards-gallery--express-milo--adobecom.aem.live/express/learn/students?martech=off
