### PR TITLE
MWPW-174872: removing card highlight variant

### DIFF
--- a/express/code/blocks/cards/cards.js
+++ b/express/code/blocks/cards/cards.js
@@ -6,6 +6,10 @@ let createTag;
  * @param {HTMLDivElement} $block
  */
 export default async function decorate($block) {
+  /** removing the highlight variant only  */
+  const isAxColumnsHighlight = $block?.parentElement?.querySelector('.highlight');
+  if (isAxColumnsHighlight) return $block?.parentElement?.remove();
+
   await Promise.all([import(`${getLibs()}/utils/utils.js`), decorateButtonsDeprecated($block)]).then(([utils]) => {
     ({ createTag } = utils);
   });
@@ -27,4 +31,6 @@ export default async function decorate($block) {
       }
     });
   });
+
+  return $block;
 }


### PR DESCRIPTION
## Summary

The ask is to remove the highlight variant instead of fixing a11y issues.
- Filter out the highlight variant, if found, we remove the content, else we render the card.
---

## Jira Ticket

Resolves: [MWPW-174872](https://jira.corp.adobe.com/browse/MWPW-174872)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/create/poster |
| **After**   | https://MWPW-174872--express-milo--adobecom.aem.page/express/create/poster?martech=off |

---

## Verification Steps

Please include:
- Load the page and locate the 
- What to expect **before** : the title `Looking for Adobe Express for Education?` is present with three cards showing up. and **after** the change: `Looking for Adobe Express for Education?` is not present and the cards are removed.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
