### PR TITLE
MWPW-173192: change div > h2 and h2 > h3

### DIFF
--- a/express/code/blocks/pricing-cards/pricing-cards.css
+++ b/express/code/blocks/pricing-cards/pricing-cards.css
@@ -32,7 +32,7 @@ Legacy CSS for cards and special promo
   align-items: center;
 }
 
-.pricing-cards .card .card-header h2 {
+.pricing-cards .card .card-header h3 {
   font-weight: var(--heading-font-weight);
   line-height: var(--heading-line-height);
   font-size: 1.75rem;
@@ -80,14 +80,15 @@ End legacy CSS
 /*
 Border style variants
 */
-
-.pricing-cards .gradient-promo>div:first-of-type {
+.pricing-cards .gradient-promo>h2{
   margin-left: 4px;
   color: var(--color-white);
   font-weight: 400;
   padding-bottom: 12px;
   line-height: 1.5rem;
   text-align: center;
+  font-size: 1rem;
+  margin-top: 0px !important;
 }
 
 .pricing-cards .gradient-promo {
@@ -269,11 +270,12 @@ End border style variants
 }
 
 
-.pricing-cards .card-border .card .card-header h2 {
+.pricing-cards .card-border .card .card-header h3 {
   display: flex;
   flex-direction: row-reverse;
   gap: 8px;
   text-align: left;
+  font-size: 1.75rem;
 }
 
 .pricing-cards .card-header img {

--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -464,7 +464,7 @@ function readBraces(inputString, card) {
 
   if (matches.length > 0) {
     const [token, promoType] = matches[matches.length - 1];
-    const specialPromo = createTag('div');
+    const specialPromo = createTag('h2');
     specialPromo.textContent = inputString.split(token)[0].trim();
     card.classList.add(promoType.replaceAll(' ', ''));
     card.append(specialPromo);
@@ -475,7 +475,7 @@ function readBraces(inputString, card) {
 // Function for decorating a legacy header / promo.
 function decorateLegacyHeader(header, card) {
   header.classList.add('card-header');
-  const h2 = header.querySelector('h2');
+  const h2 = header.querySelector('h3');
   const h2Text = h2.textContent.trim();
   h2.innerHTML = '';
   const headerConfig = /\((.+)\)/.exec(h2Text);
@@ -513,19 +513,28 @@ function decorateLegacyHeader(header, card) {
 
 function decorateHeader(header, borderParams, card, cardBorder) {
   const h2 = header.querySelector('h2');
+  const headerImage = h2?.querySelector('img');
+  const h2Text = h2?.innerText.trim();
+  const h3 = createTag('h3');
+  h3.innerText = h2Text;
+
+  if (headerImage) h3.append(headerImage);
+  header.append(h3);
+  h2?.remove();
+
   // The raw text extracted from the word doc
   header.classList.add('card-header');
   const specialPromo = readBraces(borderParams?.innerText, cardBorder);
   const premiumIcon = header.querySelector('img');
   // Finds the headcount, removes it from the original string and creates an icon with the hc
   const extractHeadCountExp = /(>?)\(\d+(.*?)\)/;
-  if (extractHeadCountExp.test(h2.innerText)) {
+  if (extractHeadCountExp.test(h3.innerText)) {
     const headCntDiv = createTag('div', { class: 'head-cnt', alt: '' });
-    const headCount = h2.innerText
+    const headCount = h3.innerText
       .match(extractHeadCountExp)[0]
       .replace(')', '')
       .replace('(', '');
-    [h2.innerText] = h2.innerText.split(extractHeadCountExp);
+    [h3.innerText] = h3.innerText.split(extractHeadCountExp);
     headCntDiv.textContent = headCount;
     headCntDiv.prepend(
       createTag('img', {
@@ -535,7 +544,7 @@ function decorateHeader(header, borderParams, card, cardBorder) {
     );
     header.append(headCntDiv);
   }
-  if (premiumIcon) h2.append(premiumIcon);
+  if (premiumIcon) h3.append(premiumIcon);
   header.querySelectorAll('p').forEach((p) => {
     if (p.innerHTML.trim() === '') p.remove();
   });


### PR DESCRIPTION
## Summary

Some div content has not heading but structurally acting as one. We were asked to make it a heading h2.

- Change the div content to an H2. and h3.

NOTE: there seems to be a case where the pricing cards does not have this sub-heading. I am looking to see if I need to change to a dynamic approach instead.

---

## Jira Ticket

Resolves: [MWPW-173192](https://jira.corp.adobe.com/browse/MWPW-173192)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/pricing |
| **After**   | https://MWPW-173192--express-milo--adobecom.aem.page/express/pricing?martech=off |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
