### PR TITLE
MWPW-173192: add dynamic tag based on text content

### DIFF
--- a/express/code/blocks/pricing-cards/pricing-cards.js
+++ b/express/code/blocks/pricing-cards/pricing-cards.js
@@ -470,8 +470,14 @@ function readBraces(inputString, card) {
 
   if (matches.length > 0) {
     const [token, promoType] = matches[matches.length - 1];
-    const specialPromo = createTag('h2');
-    specialPromo.textContent = inputString.split(token)[0].trim();
+    let specialPromo = createTag('div');
+    const textContent = inputString?.split(token)[0]?.trim();
+
+    if (textContent) {
+      specialPromo = createTag('h2');
+      specialPromo.textContent = textContent;
+    }
+
     card.classList.add(promoType.replaceAll(' ', ''));
     card.append(specialPromo);
     return specialPromo;
@@ -481,7 +487,7 @@ function readBraces(inputString, card) {
 // Function for decorating a legacy header / promo.
 function decorateLegacyHeader(header, card) {
   header.classList.add('card-header');
-  const h2 = header.querySelector('h3');
+  const h2 = header.querySelector('h2');
   const h2Text = h2.textContent.trim();
   h2.innerHTML = '';
   const headerConfig = /\((.+)\)/.exec(h2Text);


### PR DESCRIPTION
## Summary

Creating a dynamic div or h2 based on the present of content (text). This is a fast follow from https://github.com/adobecom/express-milo/pull/422. 

ALSO: changed back the previous h3 to h2 look up on the legacy cards.

---

## Jira Ticket

Resolves: [MWPW-173192](https://jira.corp.adobe.com/browse/MWPW-173192)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/pricing |
| **After**   | https://MWPW-173192--express-milo--adobecom.aem.page/express/pricing?martech=off |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
