### PR TITLE
Update frictionless-quick-action.css

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -3,6 +3,10 @@
     --frictionless-quick-action-video-height: 455px;
 }
 
+.frictionless-quick-action video, .frictionless-quick-action img:not(.icon) {
+    max-width: var(--frictionless-quick-action-video-width);
+}
+
 .frictionless-quick-action {
     padding: 40px 20px;
     max-width: none;


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Restores the max width for the marquee image in the frictionless QA block
 
---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/feature/ai/image/remove-background |
| **After**   | https://frictionless-qa-max-width--express-milo--adobecom.aem.page/express/feature/ai/image/remove-background |
| **After** | https://frictionless-qa-max-width--express-milo--adobecom.aem.page/express/feature/image/remove-background|

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Verify that the image has a max width again
- Shrink the page down to 320px to see if behavior remains normal
- Check this old branch and verify if the same CSS rule has been restored

https://ax-columns-aria-label--express-milo--adobecom.hlx.page/express/feature/ai/image/remove-background
---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.

<img width="1428" alt="Screenshot 2025-06-18 at 11 09 23 AM" src="https://github.com/user-attachments/assets/9ee6682c-524f-4504-b7d1-8e179df812bd" />
<img width="1593" alt="Screenshot 2025-06-18 at 11 09 30 AM" src="https://github.com/user-attachments/assets/67ea18ec-b4a7-4840-97f9-d9fa2104f477" />


