### PR TITLE
MWPW-171817-MWPW-172127: Post-release fix play / pause position & heading alignment

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -447,7 +447,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
   max-width: none;
 }
 
-.gen-ai-cards.homepage.spotlight .gen-ai-cards-heading-section h3,
+.gen-ai-cards.homepage.spotlight .gen-ai-cards-heading-section h2,
 .gen-ai-cards.homepage.spotlight .gen-ai-cards-heading-section p {
   text-align: left;
   max-width: none;

--- a/express/code/scripts/utils/media.js
+++ b/express/code/scripts/utils/media.js
@@ -65,7 +65,8 @@ export function addAnimationToggle(target) {
 }
 
 export async function createAccessibilityVideoControls(videoElement) {
-  const videoContainer = videoElement?.closest('.hero-animation-overlay');
+  const videoContainer = createTag('div', { class: 'video-container' });
+  const videoAnimation = videoElement?.closest('.hero-animation-overlay');
   const [federated] = await Promise.all([import(`${getLibs()}/utils/federated.js`)]);
 
   const { getFederatedContentRoot } = federated;
@@ -114,7 +115,9 @@ export async function createAccessibilityVideoControls(videoElement) {
     controlsWrapper.setAttribute('aria-label', videoLabels.playMotion);
   });
 
+  videoContainer.appendChild(videoElement);
   videoContainer.appendChild(controlsWrapper);
+  videoAnimation.appendChild(videoContainer);
   addAnimationToggle(controlsWrapper);
   return videoElement;
 }

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1423,3 +1423,11 @@ body:not(.blog) main #hero:not(:has(.hero-bg)) p {
 .video-controls-wrapper[aria-pressed="false"] .accessibility-control.icon-pause-video {
   display: none;
 }
+
+.hero-animation-overlay.column > .video-container {
+  position: relative;
+}
+
+.hero-animation-overlay.column > .video-container > .video-controls-wrapper{
+  right: 15px;
+}


### PR DESCRIPTION
## Summary

We have two regressions coming from the release:
1 - Misalignment on the h2 gen-ai homepage-spotlight: Introduced here MWPW-172127. PR https://github.com/adobecom/express-milo/pull/429
2 - Play / pause button in hero-animation column variant. Originally from MWPW-171817. PR https://github.com/adobecom/express-milo/pull/379

- Revert the h3 > h2 update
- Create a container for the video element, so the video element rather the parent content

---

## Jira Ticket

Resolves: [MWPW-171817](https://jira.corp.adobe.com/browse/MWPW-171817)

---

## Test URLs
| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/uk/express/spotlight/designwithexpress |
| **After**   | https://video-buttons-and-alignment-fix--express-milo--adobecom.aem.page/uk/express/spotlight/designwithexpress?martech=off |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:
Remove background:
main: https://main--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off
feature branch: https://video-buttons-and-alignment-fix--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
