### PR TITLE
[Chore] Add business hours restrictions and QA Approved label support

### DIFF
--- a/.github/workflows/helpers.js
+++ b/.github/workflows/helpers.js
@@ -144,6 +144,16 @@ const slackNotification = (text, webhook) => {
   });
 };
 
+const workingHours = () => {
+  const now = new Date();
+  const day = now.getUTCDay();
+  const hour = now.getUTCHours();
+  const isSunday = day === 0;
+  const isSaturday = day === 6;
+  const isFriday = day === 5;
+  return hour >= 8 && hour <= 20 && !isFriday && !isSaturday && !isSunday;
+};
+
 const addLabels = ({ pr, github, owner, repo }) =>
   github.rest.issues
     .listLabelsOnIssue({ owner, repo, issue_number: pr.number })
@@ -197,6 +207,7 @@ export {
   isShortRCP,
   isWithinRCP,
   RCPDates,
+  workingHours,
 };
 
 export const pulls = { addLabels, addFiles, getChecks, getReviews };

--- a/.github/workflows/merge-to-main.js
+++ b/.github/workflows/merge-to-main.js
@@ -1,7 +1,8 @@
 import {
   getLocalConfigs,
   isWithinRCP,
-  pulls
+  pulls,
+  workingHours
 } from './helpers.js';
 
 const { addLabels, addFiles, getChecks, getReviews } = pulls;
@@ -159,6 +160,10 @@ const main = async (params) => {
   
   if (isWithinRCP({ offset: process.env.MAIN_RCP_OFFSET_DAYS || 2, excludeShortRCP: true })) {
     return console.log('Stopped, within RCP period.');
+  }
+
+  if (!workingHours()) {
+    return console.log('Stopped, outside working hours.');
   }
 
   try {

--- a/.github/workflows/merge-to-stage.js
+++ b/.github/workflows/merge-to-stage.js
@@ -18,6 +18,7 @@ const LABELS = {
   readyForStage: 'Ready for Stage',
   readyForReview: 'Ready for Review',
   zeroImpact: 'zero-impact',
+  qaApproved: 'QA Approved',
 };
 
 // Check configuration
@@ -106,9 +107,9 @@ const getPRs = async () => {
     .then(({ data }) => data);
   await Promise.all(prs.map((pr) => addLabels({ pr, github, owner, repo })));
   
-  // Filter PRs that have Ready for Stage but not Ready for Review
+  // Filter PRs that have Ready for Stage OR QA Approved but not Ready for Review
   prs = prs.filter((pr) => 
-    pr.labels.includes(LABELS.readyForStage) && 
+    (pr.labels.includes(LABELS.readyForStage) || pr.labels.includes(LABELS.qaApproved)) && 
     !pr.labels.includes(LABELS.readyForReview)
   );
 


### PR DESCRIPTION
## Summary

- Business hours: Added working hours check (8 AM - 8 PM UTC, Monday-Thursday) to merge-to-main workflow, matching Milo's implementation
- QA Approved label: merge-to-stage now processes PRs with either "Ready for Stage" or "QA Approved" labels
- Schedule: merge-to-stage runs every 4 hours without business hours restrictions; merge-to-main runs every 4 hours with business hours restrictions

## Impact

- Prevents automated merges outside business hours (merge-to-main only)
- Enables QA team to trigger stage merges by applying "QA Approved" label
- Maintains existing approval and check requirements

---

## Jira Ticket

Housekeeping chore, but part of the original intent of [MWPW-161023
](https://jira.corp.adobe.com/browse/MWPW-161023)