### PR TITLE
[MWPW-174218] Get Started Blade Blocks Stand-alone Ready

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 ## Test URLs
 
-| Environment | URL |
+| Env | URL |
 |-------------|-----|
 | **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
 | **After**   | https://<branch>--express-milo--adobecom.aem.page/express/?martech=off |
@@ -21,15 +21,12 @@ Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 ## Verification Steps
 
-Please include:
 - Steps to reproduce the issue or view the new feature.
 - What to expect **before** and **after** the change.
 
 ---
 
 ## Potential Regressions
-
-List any areas or URLs that could be affected by this change:
 
 - https://<branch>--express-milo--adobecom.aem.live/express/?martech=off
 

--- a/express/code/blocks/ax-panels/ax-panels.css
+++ b/express/code/blocks/ax-panels/ax-panels.css
@@ -14,6 +14,10 @@
   background: #f8f8f8;
 }
 
+.section[data-ax-panel][role='tabpanel'] [data-block-status] {
+  max-width: initial;
+}
+
 .ax-panels {
   --white-background: #e1e1e1;
 

--- a/express/code/blocks/ax-panels/ax-panels.js
+++ b/express/code/blocks/ax-panels/ax-panels.js
@@ -56,7 +56,7 @@ export default async function init(el) {
     tab.setAttribute('tabIndex', '0');
     tab.focus();
     panels.forEach((panel) => panel.classList.add('hide'));
-    document.getElementById(tab.getAttribute('aria-controls')).classList.remove('hide');
+    document.getElementById(tab.getAttribute('aria-controls'))?.classList?.remove('hide');
     tab.scrollIntoView({ behavior: 'smooth', inline: 'start', block: 'nearest' });
   };
 
@@ -68,11 +68,11 @@ export default async function init(el) {
       role: 'tab',
       'aria-selected': index === 0,
       id: tabId,
-      'aria-controls': controlledPanel.id,
+      'aria-controls': controlledPanel?.id,
       tabIndex: index > 0 ? '-1' : '0',
     });
-    controlledPanel.setAttribute('aria-labelledby', tabId);
-    if (index > 0) controlledPanel.classList.add('hide');
+    controlledPanel?.setAttribute('aria-labelledby', tabId);
+    if (index > 0) controlledPanel?.classList.add('hide');
     const icon = listItem.querySelector('.icon');
     const match = icon && iconRegex.exec(icon.className);
     if (match?.[1]) {

--- a/express/code/blocks/cta-cards/cta-cards.css
+++ b/express/code/blocks/cta-cards/cta-cards.css
@@ -1,3 +1,8 @@
+.cta-cards {
+  max-width: var(--ax-grid-10-col-width);
+  margin: auto;
+}
+
 .cta-cards .heading-container {
   padding-bottom: var(--spacing-600);
   display: flex;

--- a/express/code/blocks/hover-cards/hover-cards.css
+++ b/express/code/blocks/hover-cards/hover-cards.css
@@ -1,5 +1,7 @@
 .hover-cards {
   --box-shadow-vertical-offset: 7px;
+  max-width: var(--ax-grid-10-col-width);
+  margin: auto;
 }
 
 .hover-cards .heading-container {
@@ -21,7 +23,7 @@
 }
 
 .hover-cards .gallery {
-  padding: var(--box-shadow-vertical-offset) 0;
+  padding: var(--box-shadow-vertical-offset);
   gap: var(--spacing-300);
 }
 

--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.css
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.css
@@ -188,7 +188,6 @@
 .template-x-carousel-toolbar .template img:not(.icon),
 .template-x-carousel-toolbar .template video {
   display: block;
-  width: 100%;
   height: 100%;
   pointer-events: none;
   object-fit: cover;
@@ -350,7 +349,7 @@
 
 .template-x-carousel-toolbar .template .media-wrapper {
   position: relative;
-  height: 100%;
+  height: var(--template-height);
   width: 100%;
 }
 

--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.css
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.css
@@ -11,6 +11,8 @@
   --toolbar-gap: 20px;
 
   padding-bottom: var(--template-expand-bot-len);
+  max-width: var(--ax-grid-10-col-width);
+  margin: auto;
   display: flex;
   flex-direction: column; 
 }


### PR DESCRIPTION
## Summary

Right now new blocks introduced for Get Started Blade work well together, but don't work well when authored separately. This PR is to make them more usable even when authored individually on a page, like our documentations space.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-174218

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.live/docs/library/kitchen-sink/hover-cards |
| **After**   | https://get-started-blocks-docs--express-milo--adobecom.aem.live/docs/library/kitchen-sink/hover-cards?martech=off |
| **Before**  | https://stage--express-milo--adobecom.aem.live/docs/library/kitchen-sink/cta-cards |
| **After**   | https://get-started-blocks-docs--express-milo--adobecom.aem.live/docs/library/kitchen-sink/cta-cards?martech=off |
| **Before**  | https://stage--express-milo--adobecom.aem.live/docs/library/kitchen-sink/ax-panels |
| **After**   | https://get-started-blocks-docs--express-milo--adobecom.aem.live/docs/library/kitchen-sink/ax-panels?martech=off |
| **Before**  | https://stage--express-milo--adobecom.aem.live/docs/library/kitchen-sink/template-x-carousel-toolbar |
| **After**   | https://get-started-blocks-docs--express-milo--adobecom.aem.live/docs/library/kitchen-sink/template-x-carousel-toolbar?martech=off |

---

## Verification Steps

Please include:
- They should be broken in stage but functional in the after link

---

## Potential Regressions

These blocks are not live yet, but they should continue working together nicely.

- https://get-started-blocks-docs--express-milo--adobecom.aem.live/drafts/jingle/getting-started?martech=off
