### PR TITLE
[Bug] Discover More Cards Cut-off - Mobile

### DIFF
--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -71,7 +71,7 @@ main .section .discover-cards {
   max-width: 100vw;
   margin-left: auto;
   margin-right: auto;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 /* Ensure single card is always centered */
@@ -207,6 +207,7 @@ main .section .discover-cards {
       padding-right: var(--spacing-500);
       scroll-padding-left: var(--spacing-500);
       scroll-padding-right: var(--spacing-500);
+      justify-content: center;
     }
 }
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR:
* Ensures mobile carousel is able to scroll fully left and right on mobile

---

## Jira Ticket

Resolves: [MWPW-175413](https://jira.corp.adobe.com/browse/MWPW-175413)

---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/create/brochure/tri-fold-new  |
| **After**   | https://discover-more-cards-mobile-bug--express-milo--adobecom.aem.page/express/create/brochure/tri-fold-new |

---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://stage--express-milo--adobecom.aem.live/express/create/brochure/tri-fold-new

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
