### PR TITLE
fix mobile dropzone overlap / video

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -141,6 +141,11 @@
     margin-bottom: 0;
 }
 
+.frictionless-quick-action-mobile .video-container {
+    position: relative;
+    height: 100%;
+}
+
 .frictionless-quick-action-mobile .extra-container {
     padding-top: 16px;
     text-align: center;


### PR DESCRIPTION
## Summary

Related to https://github.com/adobecom/express-milo/pull/439. 
---

## Jira Ticket

Related to: [MWPW-171817](https://jira.corp.adobe.com/browse/MWPW-171817)
Related to: [MWPW-172127](https://jira.corp.adobe.com/browse/MWPW-172127)
---

## Test URLs

| Environment | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/fr/express/feature/image/remove-background-new/white |
| **After**   | https://frictionless-video-overlap--express-milo--adobecom.aem.page/fr/express/feature/image/remove-backgroundnew/white?martech=off |
---

## Verification Steps

Please include:
- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

List any areas or URLs that could be affected by this change:

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
