### PR TITLE
MWPW-172127-2: refactor gen-ai card DOM for flex layout

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -101,7 +101,7 @@
 .gen-ai-cards .gen-ai-cards-heading-section h2 {
   text-align: left; 
   margin-bottom: 8px;
-  font-size: var(--heading-font-size-l);
+  font-size: var(--heading-font-size-m);
   line-height: 2.925rem;
   max-width: 800px;
 }
@@ -162,7 +162,7 @@
   margin: 0px;
   background-color: var(--color-background-light);
   display: flex;
-  justify-content: space-between;
+  /* justify-content: space-between; */
   align-items: flex-start;
   transition: width var(--transition-duration) var(--transition-timing), 
               min-width var(--transition-duration) var(--transition-timing), 
@@ -190,6 +190,18 @@
 
 .gen-ai-cards .card .text-wrapper p {
   margin: 0;
+}
+.gen-ai-cards .card .content-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.gen-ai-cards:not(.homepage) .card .content-wrapper,
+.gen-ai-cards.homepage.spotlight .card .content-wrapper {
+  height: 100%;
 }
 
 .gen-ai-cards .card .text-wrapper .cta-card-title {
@@ -253,7 +265,7 @@ main .gen-ai-cards.homepage .card .media-wrapper {
 }
 
 .gen-ai-cards.homepage.spotlight .card .media-wrapper {
-  width: 268px;
+  width: 100%;
   height: 228px;
 }
 
@@ -278,7 +290,7 @@ main .gen-ai-cards.homepage .card .media-wrapper {
   left: 50%;
   top: 100%;
   display: flex;
-  justify-content: space-between;
+  width: 100%;
 }
 
 .gen-ai-cards .card .gen-ai-input-form input {
@@ -327,7 +339,7 @@ main .gen-ai-cards.homepage .card .media-wrapper {
 }
 
 .gen-ai-cards.homepage .carousel-container .carousel-element.card:nth-child(2) {
-  margin-left: 24px;
+  margin-left: 20px;
 }
 
 .gen-ai-cards .card .gen-ai-input-form .gen-ai-submit {
@@ -370,6 +382,11 @@ main .gen-ai-cards.homepage .card .media-wrapper {
   padding-bottom: 8px;
 }
 
+.gen-ai-cards.homepage .card .links-wrapper {
+  padding-bottom: unset;
+  padding-top: 10px;
+}
+
 .gen-ai-cards .card .links-wrapper a {
   margin: 4px auto;
   width: max-content;
@@ -402,6 +419,10 @@ main .gen-ai-cards.homepage .carousel-container .carousel-platform.right-fader:n
   mask-image: none;
 }
 
+main .gen-ai-cards.homepage .carousel-container .carousel-platform.left-fader {
+  padding-right: 20px;
+}
+
 main .gen-ai-cards.homepage .carousel-container .carousel-fader-left {
   align-items: end;
   top: 45px;
@@ -422,7 +443,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right {
 }
 
 .gen-ai-cards.homepage .gen-ai-cards-heading {
-  font-size: var(--font-size-heading-mobile);
+  font-size: var(--heading-font-size-m);
   text-align: center;
 }
 
@@ -632,7 +653,7 @@ main .gen-ai-cards.homepage .carousel-container .carousel-fader-right.arrow-hidd
   }
 
   main .gen-ai-cards.homepage .gen-ai-cards-heading {
-    font-size: var(--heading-font-size-m);
+    font-size: var(--heading-font-size-l);
   }
 
   .gen-ai-cards .card .gen-ai-input-form {

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.css
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.css
@@ -162,7 +162,6 @@
   margin: 0px;
   background-color: var(--color-background-light);
   display: flex;
-  /* justify-content: space-between; */
   align-items: flex-start;
   transition: width var(--transition-duration) var(--transition-timing), 
               min-width var(--transition-duration) var(--transition-timing), 

--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.js
@@ -152,7 +152,10 @@ async function decorateCards(block, { actions }) {
     const linksWrapper = createTag('div', { class: 'links-wrapper' });
     const mediaWrapper = createTag('div', { class: 'media-wrapper' });
     const textWrapper = createTag('div', { class: 'text-wrapper' });
-    card.append(mediaWrapper, textWrapper, linksWrapper);
+    const cardContentWrapper = createTag('div', { class: 'content-wrapper' });
+    cardContentWrapper.append(textWrapper, linksWrapper);
+
+    card.append(mediaWrapper, cardContentWrapper);
     if (image) {
       mediaWrapper.append(image);
       if (i > 0) {
@@ -167,7 +170,7 @@ async function decorateCards(block, { actions }) {
       if (hasGenAIForm) {
         const genAIForm = buildGenAIForm(cta);
         card.classList.add('gen-ai-action');
-        card.append(genAIForm);
+        cardContentWrapper.append(genAIForm);
         linksWrapper.remove();
       } else {
         const a = ctaLinks[0];


### PR DESCRIPTION
## Summary

This is a follow up for https://github.com/adobecom/express-milo/pull/429. Some were slightly directly, others were things Mariah found.

1 - Due to the content order switch the card layout change a bit, so the spacing below the image was getting dynamic spacing based on 1 or two lines. That created misalignment in titles (worse in mobile view)
- Reactor the card content: Media is separated from the text and footer. 

2 - Carousel was not adding right space when it hit the last one.
- Add padding on left-fader

3 - Spotlight card had a fix width creating a break in design.
- Set width to 100%

4 - Font size homepage heading was wrong on both desktop and mobile
- Change desktop heading to 36px and Mobile to 28px

5 - Homepage carousel container margin was off by 4 px
- Change margin to 20px

---

## Jira Ticket

Resolves: [MWPW-172127](https://jira.corp.adobe.com/browse/MWPW-172127)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://MWPW-172127-2--express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions
GenAI
https://main--express-milo--adobecom.aem.page/express/ai?martech=off
https://MWPW-172127-2--express-milo--adobecom.aem.page/express/ai?martech=off 

SPOTLIGHT 
https://main--express-milo--adobecom.aem.page/uk/express/spotlight/designwithexpress?martech=off
https://MWPW-172127-2--express-milo--adobecom.aem.page/uk/express/spotlight/designwithexpress?martech=off

---
## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
