### PR TITLE
MWPW-175611: mitigate 404 on promotion.css

### DIFF
--- a/express/code/blocks/promotion/promotion.css
+++ b/express/code/blocks/promotion/promotion.css
@@ -1,0 +1,1 @@
+/* Empty file to avoid 404 on block code removal */


### PR DESCRIPTION
## Summary

When we removed the promotions block via code, i remove the promotion.css file. That is creating a 404 on the logs.

- Add promotion.css file again with comments to remove the 404

---

## Jira Ticket

Resolves: [MWPW-175611](https://jira.corp.adobe.com/browse/MWPW-175611)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/feature/image/remove-background |
| **After**   | https://MWPW-175611--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off |
---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
1 - After loading the page, go the network tab
2 - type promotion on the filter side
- What to expect **before** and **after** the change.
1 - you should see the promotion.css file being loaded with empty rules and comment

---

## Potential Regressions

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
