### PR TITLE
Multiple Header Support For Browse By Category

### DIFF
--- a/express/code/blocks/browse-by-category/browse-by-category.js
+++ b/express/code/blocks/browse-by-category/browse-by-category.js
@@ -70,7 +70,7 @@ export default async function decorate(block) {
   const headingDiv = rows.shift();
 
   const payload = {
-    heading: headingDiv.querySelector('h4') ? headingDiv.querySelector('h4').textContent.trim() : '',
+    heading: headingDiv.querySelector('h2, h3, h4') ? headingDiv.querySelector('h2, h3, h4').textContent.trim() : '',
     viewAllLink: {
       text: headingDiv.querySelector('a.button') ? headingDiv.querySelector('a.button').textContent.trim() : '',
       href: headingDiv.querySelector('a.button') ? headingDiv.querySelector('a.button').href : '',


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Enables support for H2-H4 for this browse by category block

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-173084

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://browse-by-category-h2--express-milo--adobecom.aem.page/express/templates/ |
| **After** |  https://browse-by-category-h2--express-milo--adobecom.aem.page/drafts/echen/browse-by-category|

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- We expect the stage version to have the header and the 3 versions shown on the draft page to have headers that look alike
 
---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
