### PR TITLE
Update quotes.css

### DIFF
--- a/express/code/blocks/quotes/quotes.css
+++ b/express/code/blocks/quotes/quotes.css
@@ -111,11 +111,11 @@
 /* Quotes container styles */
 .quotes {
   margin-top: 40px;
+  padding-bottom: 40px;
   display: flex;
   flex-direction: column;
   gap: 16px;
 }
-
 
 .section:not(.xxxl-spacing-static, .xxl-spacing-static, .xl-spacing-static, .xxxl-spacing, .xxl-spacing, .xl-spacing,
 .l-spacing, .m-spacing, .s-spacing, .xs-spacing, .xxs-spacing) .quotes:last-child {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Restores the missing margin padding for the header of the quotes block introduced by https://github.com/adobecom/express-milo/pull/444

---

## Jira Ticket

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://quote-padding-fix--express-milo--adobecom.aem.page/education/express/ |
| **After** | https://quote-padding-fix--express-milo--adobecom.aem.page/uk/drafts/jsandlan/uk-campaign-ratings |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Verify that the margin between the heading and the quotes block is back on the test page
---

## Potential Regressions

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
