### PR TITLE
[MWPW-175666] opt full-screen-marquee out of accessibility controls

### DIFF
--- a/express/code/blocks/fullscreen-marquee/fullscreen-marquee.js
+++ b/express/code/blocks/fullscreen-marquee/fullscreen-marquee.js
@@ -12,7 +12,7 @@ function buildContent(content) {
   if (contentLink && contentLink.href.endsWith('.mp4')) {
     const video = new URL(contentLink.textContent.trim());
     const looping = ['true', 'yes', 'on'].includes(video.searchParams.get('loop'));
-    formattedContent = transformLinkToAnimation(contentLink, looping);
+    formattedContent = transformLinkToAnimation(contentLink, looping, false);
   } else {
     const contentImage = content.querySelector('picture');
 

--- a/express/code/scripts/utils/media.js
+++ b/express/code/scripts/utils/media.js
@@ -122,7 +122,7 @@ export async function createAccessibilityVideoControls(videoElement) {
   return videoElement;
 }
 
-export function transformLinkToAnimation($a, $videoLooping = true) {
+export function transformLinkToAnimation($a, $videoLooping = true, hasControls = true) {
   if (!$a || !$a.href || !$a.href.endsWith('.mp4')) {
     return null;
   }
@@ -166,7 +166,8 @@ export function transformLinkToAnimation($a, $videoLooping = true) {
       });
     }
   });
-  createAccessibilityVideoControls($video);
+  // TODO: make this authorable or edit all blocks that use this func
+  if (hasControls) createAccessibilityVideoControls($video);
   // addAnimationToggle($video);
 
   return $video;


### PR DESCRIPTION
## Summary

Fix an issue introduced when adding accessibility controls to all videos. Now fullscreen-marquee opts out. Future plan is to do either a block audit or make it authorable.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-175666

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.live/express/create/video/tiktok |
| **After**   | https://hotfix-fullscreen-marquee--express-milo--adobecom.aem.live/express/create/video/tiktok?martech=off |

---

## Verification Steps
- The central video is not playing on stage, but fixed in the dev branch
