### PR TITLE
[Accessibility Update] Add Max Width to AI Marquee 

### DIFF
--- a/express/code/blocks/grid-marquee/grid-marquee.css
+++ b/express/code/blocks/grid-marquee/grid-marquee.css
@@ -2,7 +2,8 @@
   --m-img-w: 152px;
   --t-img-w: 304px;
   --d-img-w: 254px;
-  max-width: initial;
+  max-width: 812px;
+  margin: auto;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary

**Briefly describe the features or fixes introduced in this PR**

**Apply a max-width constraint of 812px to the main content block that contains**:
* The Adobe Express logo
* The H1 heading (“Bring ideas to life faster with generative AI.”)
* The supporting subtext
* The CTA button (“Create your design now”)


---

## Jira Ticket

Resolves: [MWPW-171400](https://jira.corp.adobe.com/browse/MWPW-171400)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ai |
| **After**   | https://ai-marquee-max-width--express-milo--adobecom.aem.page/express/ai |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

---

## Additional Notes

