### PR TITLE
[MWPW-176361] Filter Invalid Templates for Template-x-carousel-toolbar

### DIFF
--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
@@ -1,5 +1,5 @@
 import { getLibs, getIconElementDeprecated } from '../../scripts/utils.js';
-import { fetchResults } from '../../scripts/template-utils.js';
+import { fetchResults, isValidTemplate } from '../../scripts/template-utils.js';
 import renderTemplate from '../template-x/template-rendering.js';
 import buildGallery from '../../scripts/widgets/gallery/gallery.js';
 
@@ -10,7 +10,11 @@ const fromScratchFallbackLink = 'https://adobesparkpost.app.link/c4bWARQhWAb';
 
 async function createTemplates(recipe) {
   const res = await fetchResults(recipe);
-  const templates = await Promise.all(res.items.map((item) => renderTemplate(item)));
+  const templates = await Promise.all(
+    res.items
+      .filter((item) => isValidTemplate(item))
+      .map((item) => renderTemplate(item)),
+  );
   templates.forEach((tplt) => tplt.classList.add('template'));
   return templates;
 }

--- a/express/code/scripts/template-utils.js
+++ b/express/code/scripts/template-utils.js
@@ -82,3 +82,12 @@ export function extractComponentLinkHref(template) {
 export function containsVideo(page) {
   return !!page?.rendition?.video?.thumbnail?.componentId;
 }
+
+export function isValidTemplate(template) {
+  return !!(template.status === 'approved'
+      && template.customLinks?.branchUrl
+      && (template.assetType === 'Webpage_Template' || template.pages?.[0]?.rendition?.image?.thumbnail?.componentId)
+      && template._links?.['http://ns.adobe.com/adobecloud/rel/rendition']?.href?.replace
+      && template._links?.['http://ns.adobe.com/adobecloud/rel/component']?.href?.replace
+  );
+}


### PR DESCRIPTION
## Summary

Filtered out invalid templates that could cause Template-x-carousel-toolbar rendering errors.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-176361

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/drafts/yge/en/create/new-layout/poster/classroom |
| **After**   | https://template-carousel-filter-invalid--express-milo--adobecom.aem.page/drafts/yge/en/create/new-layout/poster/classroom?martech=off |

---

## Verification Steps
- Visit the url and scroll down a bit to see the blade and Templates tab
- On the stage link, the block should fail to load, as that page's particular query will trigger an invalid template.
- On the dev branch link, the block should continue to function.

--
