### PR TITLE
[No JIRA] Fix: apply animation only if element exists

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.js
@@ -220,7 +220,7 @@ export default async function decorate(block) {
   ui2SDK = () => {
     fadeOut(dropzoneContainer);
     fadeOut(extraContainer);
-    fadeOut(localeDropdownWrapper);
+    if (localeDropdownWrapper) fadeOut(localeDropdownWrapper);
     logo.classList.add('hide');
     if (postUploadHeadlineText) {
       h1.textContent = postUploadHeadlineText;
@@ -230,7 +230,7 @@ export default async function decorate(block) {
   ui2Landing = () => {
     fadeIn(dropzoneContainer);
     fadeIn(extraContainer);
-    fadeIn(localeDropdownWrapper);
+    if (localeDropdownWrapper) fadeIn(localeDropdownWrapper);
     logo.classList.remove('hide');
     if (postUploadHeadlineText) {
       h1.textContent = landingHeadlineText;


### PR DESCRIPTION
## Summary

Added a null check if (localeDropdownWrapper) before calling fadeOut(localeDropdownWrapper) to prevent potential errors when the locale dropdown wrapper doesn't exist. This ensures the UI transition functions work correctly even when the locale dropdown hasn't been created (which only happens for the 'caption-video' quick action type).

Mobile only issue

---

## Jira Ticket

Resolves: No JIRA

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://rkalyankumar-mobile-fix--express-milo--adobecom.aem.page/express/features/video/drafts/video-to-gif |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
