### PR TITLE
[MWPW-176512] SUSI B2B background color in Login page

### DIFF
--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -155,7 +155,8 @@
 .section.ax-login-page .susi-light {
   padding-bottom: var(--spacing-700);
 }
-.section.ax-login-page .susi-tabs .footer {
+.section.ax-login-page .susi-tabs .footer,
+.section.ax-login-page .susi-b2b .footer {
   border-radius: 8px;
 }
 
@@ -164,7 +165,8 @@
     position: absolute;
     padding-top: 30px;
   }
-  .section.ax-login-page .susi-tabs .footer {
+  .section.ax-login-page .susi-tabs .footer,
+  .section.ax-login-page .susi-b2b .footer {
     border-radius: 0 0 16px 16px;
   }
 }

--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -146,7 +146,8 @@
 }
 
 /* ax-login-page section metadata styles */
-.section.ax-login-page .susi-tabs {
+.section.ax-login-page .susi-tabs,
+.section.ax-login-page .susi-b2b {
   background-color: var(--color-white);
   border-radius: 16px;
 }

--- a/express/code/blocks/susi-light/susi-light.css
+++ b/express/code/blocks/susi-light/susi-light.css
@@ -1,12 +1,18 @@
+:root {
+  --susi-modal-width: 370px;
+  --susi-tabs-width: 400px;
+  --susi-min-height: 462px;
+}
+
 /* preserving modal space for ux */
 .dialog-modal:has(.susi-light) {
-  width: 370px;
-  min-height: 462px;
+  width: var(--susi-modal-width);
+  min-height: var(--susi-min-height);
 }
 
 .dialog-modal:has(.susi-light.tabs) {
-  width: 400px;
-  min-height: 462px;
+  width: var(--susi-tabs-width);
+  min-height: var(--susi-min-height);
 }
 
 .section.ax-login-page .susi-light .express-logo,
@@ -77,7 +83,7 @@
 }
 
 .susi-tabs [role='tabpanel'] {
-  width: 400px;
+  width: var(--susi-tabs-width);
   max-width: 95vw;
 }
 
@@ -154,6 +160,9 @@
 
 .section.ax-login-page .susi-light {
   padding-bottom: var(--spacing-700);
+}
+.section.ax-login-page .susi-b2b {
+  width: var(--susi-modal-width);
 }
 .section.ax-login-page .susi-tabs .footer,
 .section.ax-login-page .susi-b2b .footer {

--- a/express/code/blocks/susi-light/susi-light.js
+++ b/express/code/blocks/susi-light/susi-light.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable camelcase */
 import { getLibs, getIconElementDeprecated } from '../../scripts/utils.js';
+import { getTrackingAppendedURL } from '../../scripts/branchlinks.js';
 
 let createTag; let loadScript;
 let getConfig; let isStage;
@@ -31,10 +32,10 @@ export const SUSIUtils = {
   },
 };
 
-function getDestURL(url) {
+async function getDestURL(url) {
   let destURL;
   try {
-    destURL = new URL(url);
+    destURL = await getTrackingAppendedURL(url);
   } catch (err) {
     window.lana?.log(`invalid redirect uri for susi-light: ${url}`);
     destURL = new URL('https://new.express.adobe.com');
@@ -171,8 +172,9 @@ async function buildEdu(el) {
   const client_id = rows[1]?.textContent?.trim() || (imsClientId ?? 'AdobeExpressWeb');
   const title = rows[2]?.textContent?.trim();
   const variant = 'edu-express';
+  const destURL = await getDestURL(redirectUrl);
   const params = buildSUSIParams({
-    client_id, variant, destURL: getDestURL(redirectUrl), locale, title,
+    client_id, variant, destURL, locale, title,
   });
   if (!noRedirect) {
     redirectIfLoggedIn(params.destURL);
@@ -195,8 +197,9 @@ async function buildB2B(el) {
   const footer = rows[3];
   footer?.classList.add('footer', 'susi-banner');
   const variant = 'standard';
+  const destURL = await getDestURL(redirectUrl);
   const susiConfigs = {
-    client_id, variant, destURL: getDestURL(redirectUrl), locale, title: '', hideIcon: true,
+    client_id, variant, destURL, locale, title: '', hideIcon: true,
   };
   if (emailFirst) {
     susiConfigs.layout = 'emailAndSocial';
@@ -220,7 +223,7 @@ async function buildB2B(el) {
 
 // each tab wraps susi component with custom logo + footer
 let tabsId = 0;
-function buildSUSITabs(el) {
+async function buildSUSITabs(el) {
   const locale = getConfig().locale.ietf.toLowerCase();
   const { imsClientId } = getConfig();
   const noRedirect = el.classList.contains('no-redirect');
@@ -230,12 +233,13 @@ function buildSUSITabs(el) {
   const redirectUrls = [...rows[3].querySelectorAll('div')].map((div) => div.textContent?.trim().toLowerCase());
   const client_ids = [...rows[4].querySelectorAll('div')].map((div) => div.textContent?.trim() || (imsClientId ?? 'AdobeExpressWeb'));
   const footers = rows[5] ? [...rows[5].querySelectorAll('div')] : [];
+  const destURLs = await Promise.all(redirectUrls.map((redirectUrl) => getDestURL(redirectUrl)));
   const tabParams = tabNames.map((tabName, index) => ({
     tabName,
     ...buildSUSIParams({
       client_id: client_ids[index],
       variant: variants[index],
-      destURL: getDestURL(redirectUrls[index]),
+      destURL: destURLs[index],
       locale,
       title: '', // rm titles
       hideIcon: true,
@@ -320,6 +324,6 @@ export default async function init(el) {
   if (isBusiness) {
     el.replaceChildren(await (buildB2B(el)));
   } else {
-    el.replaceChildren(buildSUSITabs(el));
+    el.replaceChildren(await (buildSUSITabs(el)));
   }
 }


### PR DESCRIPTION
## Summary

Added background to b2b SUSI when wrapped in login page. By default, SUSI still comes with no background and rely on page styles where they are authored.

---

## Jira Ticket

Resolves:
- https://jira.corp.adobe.com/browse/MWPW-176512
- https://jira.corp.adobe.com/browse/MWPW-176513

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/spotlight/business/login |
| **After**   | https://susi-background--express-milo--adobecom.aem.page/express/spotlight/business/login?martech=off 
| **Before**  | https://stage--express-milo--adobecom.aem.live/express/spotlight/business?promoid=Y69SGP43&mv=other#susi-1 |
| **After**   | https://susi-background--express-milo--adobecom.aem.live/express/spotlight/business?promoid=Y69SGP43&mv=other#susi-1 |

---

## Verification Steps
- Added background (first pair of URLs):
  - The stage url should have SUSI being very hard to read
  - The branch url should handle that by having a white background
- CGEN (second pair of URLs)
  - In stage, when using an email and continue, promoid and mv should be dropped
  - In branch url, they will be carried over

---
