### PR TITLE
Pricing Card CSS Fix

### DIFF
--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -438,7 +438,7 @@ main .section>.simplified-pricing-cards-wrapper {
 
 @media (min-width: 1280px) {
     .simplified-pricing-cards {
-        --card-width: 270px;
+        --card-width: 294px;
         --header-size: 28px;
         --header-offer-size: 16px;
         padding-top: 40px;

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -71,7 +71,11 @@ main .section>.simplified-pricing-cards-wrapper {
     z-index: 2;
 }
 
-.simplified-pricing-cards .card-header h2 {
+.simplified-pricing-cards .card-header h2,
+.simplified-pricing-cards .card-header h3,
+.simplified-pricing-cards .card-header h4,
+.simplified-pricing-cards .card-header h5,
+.simplified-pricing-cards .card-header h6 {
     font-weight: var(--heading-font-weight);
     line-height: var(--heading-line-height);
     font-size: var(--header-size);
@@ -110,8 +114,13 @@ main .section>.simplified-pricing-cards-wrapper {
     text-align: left;
 }
 
-.simplified-pricing-cards .pricing-area h2 {
+.simplified-pricing-cards .pricing-area h2,
+.simplified-pricing-cards .pricing-area h3,
+.simplified-pricing-cards .pricing-area h4,
+.simplified-pricing-cards .pricing-area h5,
+.simplified-pricing-cards .pricing-area h6 {
     text-align: left;
+    font-size: var(--header-size);
 }
 
 .simplified-pricing-cards .pricing-area p {
@@ -162,10 +171,6 @@ main .section>.simplified-pricing-cards-wrapper {
     margin: 0;
     width: 0;
     height: 0;
-}
-
-.simplified-pricing-cards .pricing-area h2 {
-    font-size: var(--header-size);
 }
 
 .simplified-pricing-cards .pricing-area .pricing-row {

--- a/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
+++ b/express/code/blocks/simplified-pricing-cards/simplified-pricing-cards.css
@@ -506,16 +506,9 @@ main .section>.simplified-pricing-cards-wrapper {
     }
 
 }
-
-@media (min-width: 1440px) {
-    .simplified-pricing-cards {
-        --card-width: 294px;
-    }
-}
-
+ 
 @media (min-width: 1680px) {
-    .simplified-pricing-cards {
-        --card-width: 294px;
+    .simplified-pricing-cards { 
         --header-size: 28px;
         --header-offer-size: 16px;
     }


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.
1) Changes the width of the card from 270px to 294px on 1280px - 1440px breakpoints.
2) Updated header CSS rules to be inclusive of h3, h4, h5, and h6 elements.

**Authors seem to have added an italic to the "Contact Sales" part of the block, which should be reverted to achieve the original look*

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-176717

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://pricing-card-h3--express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the page and view the pricing cards at 1281px screen size
- The fix should look normal, the current version has an overflowing header

---

## Potential Regressions

-  https://pricing-card-h3--express-milo--adobecom.aem.page/express/?martech=off 

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
