### PR TITLE
Default Plain Text Content - Discover Page Redesign

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1137,6 +1137,7 @@ main .section.long-form .content h4,
 main .section.long-form .content h5,
 main .section.long-form .content h6 {
   text-align: left;
+  color: var(--color-gray-700);
 }
 
 main .section.long-form .content h2,

--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -1122,6 +1122,10 @@ main .section.long-form .content {
   box-sizing: border-box;
   padding: 0 20px 60px;
   max-width: unset;
+  /* Mobile: 12 columns */
+  width: var(--ax-grid-12-col-width);
+  margin-left: auto;
+  margin-right: auto;
 }
 
 main .section.long-form .content,
@@ -1158,7 +1162,19 @@ main .section.long-form .content h4 {
 @media (min-width: 600px) {
   main .section.long-form .content {
     padding: 0 40px 60px;
-    max-width: 1070px;
+    /* Tablet: 12 columns */
+    width: var(--ax-grid-12-col-width);
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+@media (min-width: 1200px) {
+  main .section.long-form .content {
+    /* Desktop: 7 columns */
+    width: var(--ax-grid-7-col-width);
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.
* applies grid to longform default text content
* color text per figma

---

## Jira Ticket

Resolves: [MWPW-172988](https://jira.corp.adobe.com/browse/MWPW-172988)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/drafts/jsandlan/discover-toc |
| **After**   | https://discover-dtc--express-milo--adobecom.aem.page/drafts/jsandlan/discover-toc/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

I don't believe long form text content is being used anywhere.

---

## Additional Notes

NA
