### PR TITLE
MWPW-174671: Make FAQ block schema optional

### DIFF
--- a/express/code/blocks/faq/faq.js
+++ b/express/code/blocks/faq/faq.js
@@ -4,7 +4,8 @@ import { trackButtonClick } from '../../scripts/instrument.js';
 let createTag; let getMetadata;
 
 function decorateFAQBlocks(block) {
-  const showSchema = getMetadata('show-faq-schema');
+  const hideSchemaPageLevel = getMetadata('show-faq-schema') === 'no';
+  const hideSchemaBlockLevel = block.classList.contains('hide-faq-schema');
   const faqs = [];
   const entities = [];
   const rows = Array.from(block.children);
@@ -47,7 +48,7 @@ function decorateFAQBlocks(block) {
     });
   });
 
-  if (showSchema !== 'no') {
+  if (!hideSchemaPageLevel && !hideSchemaBlockLevel) {
     const $schemaScript = document.createElement('script');
     $schemaScript.setAttribute('type', 'application/ld+json');
     $schemaScript.textContent = JSON.stringify({

--- a/test/blocks/faq/faq.test.js
+++ b/test/blocks/faq/faq.test.js
@@ -1,0 +1,72 @@
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+
+// eslint-disable-next-line max-len
+const [, { default: decorate }] = await Promise.all([import('../../../express/code/scripts/scripts.js'), import('../../../express/code/blocks/faq/faq.js')]);
+const [body, hideFaqSchema] = await Promise.all([
+  readFile({ path: './mocks/body.html' }),
+  readFile({ path: './mocks/hide-faq-schema.html' }),
+]);
+
+describe('FAQ', () => {
+  before(() => {
+    window.isTestEnv = true;
+  });
+
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('should render FAQ block', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('.faq');
+    await decorate(block);
+    expect(block).to.exist;
+  });
+
+  it('should inject Schema', async () => {
+    document.body.innerHTML = body;
+    const block = document.querySelector('.faq');
+    await decorate(block);
+    const script = document.querySelector('script[type="application/ld+json"]');
+    const json = JSON.parse(script.textContent);
+    expect(script).to.exist;
+    expect(json['@context']).to.equal('https://schema.org');
+    expect(json['@type']).to.equal('FAQPage');
+    expect(json.mainEntity).to.be.an('array');
+    expect(json.mainEntity[0]['@type']).to.equal('Question');
+    expect(json.mainEntity[0].name).to.equal('Question 1');
+    expect(json.mainEntity[0].acceptedAnswer['@type']).to.equal('Answer');
+    expect(json.mainEntity[0].acceptedAnswer.text).to.equal('This is the answer to question 1.');
+  });
+
+  it('should not inject Schema when hide-faq-schema class is present', async () => {
+    document.body.innerHTML = hideFaqSchema;
+    const block = document.querySelector('.faq');
+    await decorate(block);
+    const script = document.querySelector('script[type="application/ld+json"]');
+    expect(block.classList.contains('hide-faq-schema')).to.be.true;
+    expect(script).to.be.null;
+  });
+
+  it('should not inject Schema when show-faq-schema page metadata is set to no', async () => {
+    document.body.innerHTML = body;
+    document.head.innerHTML = '<meta name="show-faq-schema" content="no">';
+    const block = document.querySelector('.faq');
+    await decorate(block);
+    const script = document.querySelector('script[type="application/ld+json"]');
+    expect(script).to.be.null;
+  });
+
+  it('should not inject Schema when both hiding options used together', async () => {
+    document.body.innerHTML = hideFaqSchema;
+    document.head.innerHTML = '<meta name="show-faq-schema" content="no">';
+    const block = document.querySelector('.faq');
+    await decorate(block);
+    const script = document.querySelector('script[type="application/ld+json"]');
+    expect(script).to.be.null;
+  });
+});

--- a/test/blocks/faq/mocks/body.html
+++ b/test/blocks/faq/mocks/body.html
@@ -1,0 +1,22 @@
+<div class="faq">
+  <div>
+    <div data-valign="middle">Question 1</div>
+    <div data-valign="middle">This is the answer to question 1.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 2</div>
+    <div data-valign="middle">This is the answer to question 2.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 3</div>
+    <div data-valign="middle">This is the answer to question 3.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 4</div>
+    <div data-valign="middle">This is the answer to question 4.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 5</div>
+    <div data-valign="middle">This is the answer to question 5.</div>
+  </div>
+</div>

--- a/test/blocks/faq/mocks/hide-faq-schema.html
+++ b/test/blocks/faq/mocks/hide-faq-schema.html
@@ -1,0 +1,22 @@
+<div class="faq hide-faq-schema">
+  <div>
+    <div data-valign="middle">Question 1</div>
+    <div data-valign="middle">This is the answer to question 1.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 2</div>
+    <div data-valign="middle">This is the answer to question 2.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 3</div>
+    <div data-valign="middle">This is the answer to question 3.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 4</div>
+    <div data-valign="middle">This is the answer to question 4.</div>
+  </div>
+  <div>
+    <div data-valign="middle">Question 5</div>
+    <div data-valign="middle">This is the answer to question 5.</div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Add variant option to FAQ block to not inject JSON schema into the page heading. The variant to add is `hide-faq-schema`.
- Add unit tests for FAQ block.

---

## Jira Ticket

Resolves: [MWPW-174671](https://jira.corp.adobe.com/browse/MWPW-174671)

---

## Test URLs

Copy of Pricing page with 5 FAQs on the page. 4 of the 5 have the new `hide-faq-schema` variant applied.
| Env | URL | # of Schemas |
|-------------|-----|-----|
| **Before**  | https://main--express-milo--adobecom.hlx.page/drafts/yolles/pricing | 5 |
| **After**   | https://mwpw-174671-faq-schema--express-milo--adobecom.hlx.page/drafts/yolles/pricing?martech=off | 1 |

Single FAQ block with no variant or page meta data.
| Env | URL | # of Schemas |
|-------------|-----|-----|
| **Before**  | https://main--express-milo--adobecom.hlx.page/drafts/yolles/faq | 1 |
| **After**   | https://mwpw-174671-faq-schema--express-milo--adobecom.hlx.page/drafts/yolles/faq?martech=off | 1 |

Single FAQ block with new `hide-faq-schema` variant applied.
| Env | URL | # of Schemas |
|-------------|-----|-----|
| **Before**  | https://main--express-milo--adobecom.hlx.page/drafts/yolles/faq-no-schema | 1 |
| **After**   | https://mwpw-174671-faq-schema--express-milo--adobecom.hlx.page/drafts/yolles/faq-no-schema?martech=off | 0 |

Single FAQ block with `show-faq-schema` page metadata set to `no`.
| Env | URL | # of Schemas |
|-------------|-----|-----|
| **Before**  | https://main--express-milo--adobecom.hlx.page/drafts/yolles/faq-no-schema-metadata | 0 |
| **After**   | https://mwpw-174671-faq-schema--express-milo--adobecom.hlx.page/drafts/yolles/faq-no-schema-metadata?martech=off | 0 |
---

## Verification Steps

- Load page
- Look for script elements in the page head with the schema JSON.
- The number of script elements with the FAQ schema should match the number of blocks that don't have the new variant applied.
- There should be no script elements with FAQ schemas if the page metadata is set to no.
- You can quickly see how many FAQ schemas are on the page by querying the DOM using `document.querySelector('script[type="application/ld+json"]')`

---

## Potential Regressions

- https://mwpw-174671-faq-schema--express-milo--adobecom.hlx.page/express/pricing?martech=off
