### PR TITLE
[OPT-33868] More accurate block matching for FloatingCTA rules

### DIFF
--- a/express/code/styles/styles.css
+++ b/express/code/styles/styles.css
@@ -837,8 +837,8 @@ main .section:not(.xxxl-spacing-static,
   padding-bottom: 40px;
 }
 
-main .section>div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards) a.button.same-fcta,
-main .section>div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards) a.con-button.same-fcta,
+div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards) a.button.same-fcta,
+div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .ribbon-banner, .content, .banner, .text, .hover-cards, .cta-cards) a.con-button.same-fcta,
 #hero a.same-fcta {
   display: none;
 }
@@ -1014,8 +1014,8 @@ main .section.blog-content>.content>p {
     text-align: left;
   }
 
-  main .section>div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .text, .hover-cards, .cta-cards) a.button.same-fcta,
-  main .section>div:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .text, .hover-cards, .cta-cards) a.con-button.same-fcta {
+  div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .text, .hover-cards, .cta-cards) a.button.same-fcta,
+  div[data-block-status]:not(.pricing-cards-wrapper, .pricing-table-wrapper, .split-action-wrapper, .link-list-wrapper, .wayfinder, .ratings, .text, .hover-cards, .cta-cards) a.con-button.same-fcta {
     display: inline-block;
   }
 


### PR DESCRIPTION
## Summary

Currently. page CTAs that are considered same-cta as floatingCTA would be hidden. However, this rule runs into issues when fragments and personalization are applied. This PR aims to improve the matching.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/OPT-33868

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/?mep=%2Ffragments%2Fjpratt%2Fsandbox%2Faexg5271-1.json |
| **After**   | https://fcta-block-matching--express-milo--adobecom.aem.page/express/?mep=%2Ffragments%2Fjpratt%2Fsandbox%2Faexg5271-1.json |

---

## Verification Steps

- Emulate iOS and Load the page
- Scroll down to the tabs and click Students
- On stage, there should be an unintentionally hidden CTA. On dev branch, it should be visible

---

## Potential Regressions

- This PR should not affect any floating-cta behaviors on any pages.

---
