### PR TITLE
[Frictionless] Increase Crop Image Container Height

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -199,6 +199,10 @@
     height: 741px;
 }
 
+.frictionless-quick-action-mobile .quick-action-container#crop-image-container {
+    height: 875px;
+}
+
 .frictionless-quick-action-mobile .quick-action-container#trim-video-container {
     height: 762px;
 }


### PR DESCRIPTION
## Summary

Bump up height of crop-image-container as it now includes an extra "aspect ratio" section. We can't rely on auto height as the content streaming in could cause CLS. We woulda also target migrating to project Unity in the long run.

Slack conversation: https://adobedotcom.slack.com/archives/C081P673NA0/p1754316474585009?thread_ts=1752774559.098759&cid=C081P673NA0

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/feature/image/crop?martech=off |
| **After**   | https://<frictionless-crop-image-height>--express-milo--adobecom.aem.page/express/feature/image/crop?martech=off |

---

## Verification Steps

- Load the page using Mobile Android Emulator/Phone
- Upload an image 
- Notice that on dev branch, all content can be displayed, but in stage, they get cropped

