### PR TITLE
[Hotfix] Remove temporary block

### DIFF
--- a/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
+++ b/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
@@ -132,6 +132,7 @@ async function mWebStickyCTA() {
   data.mainCta.text = data.mainCta.forkStickyMobileText || data.mainCta.text;
   data.mainCta.href = data.mainCta.forkStickyMobileHref || data.mainCta.href;
   await createFloatingButton(oldBlock, audience, data);
+  newBlock.remove();
 }
 
 function mWebOverlayScroll() {


### PR DESCRIPTION
## Summary

Fix mobile-fork-button-dismissable block.


---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.live/express/?martech=off |
| **After**   | https://hotfix-dismiss-button--express-milo--adobecom.aem.live/express/?martech=off |

---

## Verification Steps

- Load in Android Mobile Emulator/Phone
- Dismiss the floating panel by closing it
- Scroll to bottom of the page
- On stage, you would see a weird "mobile" text floating
- On dev branch, it should be cleaned up

