### PR TITLE
[HOTFIX] MAX patch

### DIFF
--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1783,3 +1783,15 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
   }
 }
 
+/* Patch for MAX */
+.section.ax-max-entitled:has(.ax-columns) .column-picture img {
+  max-width: 384px;
+  margin-top: var(--spacing-400);
+}
+
+@media (min-width: 900px) {
+  .section.ax-max-entitled:has(.ax-columns) .column-picture img {
+    max-width: 100%;
+    margin-top: 0;
+  }
+}

--- a/express/code/blocks/ax-columns/ax-columns.css
+++ b/express/code/blocks/ax-columns/ax-columns.css
@@ -1785,7 +1785,7 @@ main .ax-columns.highlight.dark .columns-video:last-of-type {
 
 /* Patch for MAX */
 .section.ax-max-entitled:has(.ax-columns) .column-picture img {
-  max-width: 384px;
+  max-width: 100%;
   margin-top: var(--spacing-400);
 }
 


### PR DESCRIPTION
## Summary

Adds a section metadata patch style for the MAX campaign image 

---

## Jira Ticket

https://jira.corp.adobe.com/browse/MWPW-177449

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://max-patch--express-milo--adobecom.aem.page/drafts/bradjohn/max-entitled-campaign?martech=off |

---

## Verification Steps

- Check that mobile has section 400 spacing above the image on mobile
---

## Potential Regressions

None, fixed with section metadata to be non invasive 
