### PR TITLE
[DA Migration] Handle Deserialized query index JSON for DA

### DIFF
--- a/express/code/blocks/blog-posts/blog-posts.js
+++ b/express/code/blocks/blog-posts/blog-posts.js
@@ -26,7 +26,7 @@ async function fetchBlogIndex(locales) {
   const byPath = {};
   jointData.forEach((post) => {
     if (post.tags) {
-      const tags = JSON.parse(post.tags);
+      const tags = typeof post.tags === 'string' ? JSON.parse(post.tags) : post.tags;
       tags.push(post.category);
       post.tags = JSON.stringify(tags);
     }


### PR DESCRIPTION
## Summary

In DA, query-index.json would be containing JSON objects as values rather than stringified JSON. Our blog-posts block as of now dynamically fetches the json and tries to parse the values, which could crash in DA. This is a forward-compatible change.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-176253?focusedId=49107761&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-49107761

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/create/video/youtube |
| **After**   | https://blog-posts-da-migration--express-milo--adobecom.aem.page/express/create/video/youtube?martech=off |

---

## Verification Steps

- There should be no impact on this repo. But when this code gets synched to da-express-milo, it should allow blog-posts to be properly displayed displayed on https://blog-posts-da-migration--express-milo--adobecom.aem.page/express/create/video/youtube?martech=off.

