### PR TITLE
[MWPW-177665][Bug] [Create Page] Template-Carousel Default Index Fix

### DIFF
--- a/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
+++ b/express/code/blocks/template-x-carousel-toolbar/template-x-carousel-toolbar.js
@@ -173,12 +173,10 @@ export async function extractSort(recipe) {
   const recipeParams = new URLSearchParams(recipe);
   const sortKeys = Object.keys(sortConfig);
   const sortValues = Object.values(sortConfig);
-  // const [sortPlaceholderText, ...sortOptionTexts] = await Promise.all(
-  const ha = await Promise.all([
+  const [sortPlaceholderText, ...sortOptionTexts] = await Promise.all([
     replaceKey('sort', getConfig()),
     ...(sortKeys.map((key) => replaceKey(key, getConfig()))),
   ]);
-  const [sortPlaceholderText, ...sortOptionTexts] = ha;
   const sortOptions = sortKeys.map((key, i) => {
     const sortedRecipe = new URLSearchParams(recipeParams);
     sortedRecipe.set('orderBy', sortConfig[key]);
@@ -188,7 +186,7 @@ export async function extractSort(recipe) {
     };
   });
   const defaultIndex = Math.max(0, sortValues.indexOf(
-    (sortValues.includes(recipeParams.get('orderBy'))),
+    recipeParams.get('orderBy'),
   ));
   return { sortOptions, defaultIndex, sortPlaceholderText };
 }


### PR DESCRIPTION
## Summary

Fix an issue where the default sort order doesn't follow authoring.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-177665

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.live/express/create/poster |
| **After**   | https://template-carousel-default-order--express-milo--adobecom.aem.live/express/create/poster?martech=off |

---

## Verification Steps

- Scroll down to the tabs and templates section
- On stage, it would default to "Popular". On dev branch, it would default to "New templates" following the authoring.
