### PR TITLE
[MWPW-177404] FQA Mobile Resize Container Height Increase

### DIFF
--- a/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
+++ b/express/code/blocks/frictionless-quick-action-mobile/frictionless-quick-action-mobile.css
@@ -188,7 +188,7 @@
 }
 
 .frictionless-quick-action-mobile .quick-action-container#resize-image-container {
-    height: 1080px;
+    height: 1160px;
 }
 
 .frictionless-quick-action-mobile .quick-action-container#convert-to-gif-container {
@@ -259,12 +259,6 @@
     display: flex;
     align-items: center;
     cursor: pointer;
-}
-
-@media (min-width: 1200px) {
-    .frictionless-quick-action-mobile .quick-action-container#resize-image-container {
-        height: 1000px;
-    }
 }
 
 .frictionless-quick-action-mobile[data-frictionlesstype="caption-video"] .locale-dropdown-wrapper {


### PR DESCRIPTION
## Summary

Increase height of resize container to fit in more content. There will be a future plan to remove the need of hardcoded values on our end by having `<cc-everywhere-container>` expose its height requirements as an attribute.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-177404

Link to Video: https://adobe.enterprise.slack.com/files/W013JB132E7/F09AGTXA1J4/screen_recording_2025-08-10_at_2.34.41___pm.mov

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/feature/image/resize-test?martech=off |
| **After**   | https://fqa-mobile-resize-height--express-milo--adobecom.aem.page/express/feature/image/resize-test?martech=off |

---

## Verification Steps

- Load the page in Mobile Android Emulator/Phone
- Upload an image
- Select an aspect ratio and have a new row inserted
- On stage, bottom content links will be cropped. On dev branch, there should be enough space for all to be displayed

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
