### PR TITLE
Support For Multiple Pricing Tokens In Pricing Cards V2

### DIFF
--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.css
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.css
@@ -80,7 +80,6 @@ main .pricing-cards-v2-wrapper .pricing-cards-v2 .card-header h6 {
   border-radius: 8px;
   display: flex;
   flex-direction: column;
-  padding: 1px;
 }
 
 .pricing-cards-v2 .gradient-promo {
@@ -94,6 +93,7 @@ main .pricing-cards-v2-wrapper .pricing-cards-v2 .card-header h6 {
 .pricing-cards-v2 .gen-ai-promo .card,
 .pricing-cards-v2 .gradient-promo .card {
   border: 2px solid transparent;
+  margin: 1px;
 }
 
 .pricing-cards-v2 .gen-ai-promo div:empty,

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.css
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.css
@@ -80,6 +80,7 @@ main .pricing-cards-v2-wrapper .pricing-cards-v2 .card-header h6 {
   border-radius: 8px;
   display: flex;
   flex-direction: column;
+  padding: 1px;
 }
 
 .pricing-cards-v2 .gradient-promo {
@@ -93,7 +94,6 @@ main .pricing-cards-v2-wrapper .pricing-cards-v2 .card-header h6 {
 .pricing-cards-v2 .gen-ai-promo .card,
 .pricing-cards-v2 .gradient-promo .card {
   border: 2px solid transparent;
-  margin: 1px;
 }
 
 .pricing-cards-v2 .gen-ai-promo div:empty,

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -81,12 +81,9 @@ function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPri
   try {
     const paragraphs = Array.from(pricingArea.querySelectorAll('p'))
       .filter((p) => p.textContent.includes(priceToken));
-
     if (paragraphs.length === 0) return;
-
-    const hasPrice = newPrice !== undefined && newPrice !== null && `${newPrice}` !== ''; // extra checks
+    const hasPrice = newPrice !== undefined && newPrice !== null && `${newPrice}` !== '';
     const replacement = [newPrice, priceSuffix].filter(Boolean).join(' ');
-
     paragraphs.forEach((p) => {
       if (hasPrice) {
         p.innerHTML = p.innerHTML.replaceAll(priceToken, replacement);

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -79,18 +79,21 @@ async function getPriceElementSuffix(placeholderArr, response) {
 // eslint-disable-next-line default-param-last
 function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPrice, priceSuffix = '') {
   try {
-    const elements = pricingArea.querySelectorAll('p');
-    const year2PricingTokens = Array.from(elements).filter(
-      (p) => p.textContent.includes(priceToken),
-    );
-    year2PricingTokens.forEach((year2PricingToken) => {
-      if (newPrice) {
-        year2PricingToken.innerHTML = year2PricingToken.innerHTML.replace(
-          priceToken,
-          `${newPrice} ${priceSuffix}`,
-        );
+    const paragraphs = Array.from(pricingArea.querySelectorAll('p'))
+      .filter((p) => p.textContent.includes(priceToken));
+
+    if (paragraphs.length === 0) return;
+
+    const hasPrice = newPrice !== undefined && newPrice !== null && `${newPrice}` !== ''; // extra checks
+    const replacement = [newPrice, priceSuffix].filter(Boolean).join(' ');
+
+    paragraphs.forEach((p) => {
+      if (hasPrice) {
+        p.innerHTML = p.innerHTML.replaceAll(priceToken, replacement);
+      } else if (p.textContent.trim() === priceToken) {
+        p.textContent = '';
       } else {
-        year2PricingToken.textContent = '';
+        p.innerHTML = p.innerHTML.replaceAll(priceToken, '');
       }
     });
   } catch (e) {

--- a/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
+++ b/express/code/blocks/pricing-cards-v2/pricing-cards-v2.js
@@ -80,18 +80,19 @@ async function getPriceElementSuffix(placeholderArr, response) {
 function handlePriceToken(pricingArea, priceToken = YEAR_2_PRICING_TOKEN, newPrice, priceSuffix = '') {
   try {
     const elements = pricingArea.querySelectorAll('p');
-    const year2PricingToken = Array.from(elements).find(
+    const year2PricingTokens = Array.from(elements).filter(
       (p) => p.textContent.includes(priceToken),
     );
-    if (!year2PricingToken) return;
-    if (newPrice) {
-      year2PricingToken.innerHTML = year2PricingToken.innerHTML.replace(
-        priceToken,
-        `${newPrice} ${priceSuffix}`,
-      );
-    } else {
-      year2PricingToken.textContent = '';
-    }
+    year2PricingTokens.forEach((year2PricingToken) => {
+      if (newPrice) {
+        year2PricingToken.innerHTML = year2PricingToken.innerHTML.replace(
+          priceToken,
+          `${newPrice} ${priceSuffix}`,
+        );
+      } else {
+        year2PricingToken.textContent = '';
+      }
+    });
   } catch (e) {
     window.lana.log(e);
   }


### PR DESCRIPTION
## Summary

Updated the handlePriceToken function in the pricing-cards-v2 component to properly handle scenarios where multiple pricing tokens exist on a single page, rather than only processing the first occurrence.

**Page is currently under authoring, so this issue is not on production**

---

## Jira Ticket

Resolves:  https://jira.corp.adobe.com/browse/MWPW-178688

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/drafts/echen/pricing-bug-demo?tab=3 |
| **After**   | https://pricing-v3-y2p-multiple--express-milo--adobecom.aem.page/drafts/echen/pricing-bug-demo?tab=3 |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.
- Visit the link above (it should bring you to the correct pricing card tab) and verify that you do not see `[[year-2-pricing-token]]` in the cards, indicating the token processing is working.

---

## Potential Regressions

- https://stage--express-milo--adobecom.aem.page/express/pricing?tab=3 

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
