### PR TITLE
Update dismissable continue selector.

### DIFF
--- a/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
+++ b/express/code/blocks/mobile-fork-button-dismissable/mobile-fork-button-dismissable.js
@@ -157,7 +157,7 @@ function mWebBuildElements() {
 }
 
 function mWebCloseEvents() {
-  const closeElements = document.querySelectorAll('.mweb-mobile-fork a[title="Continue"], .mweb-mobile-fork a.mweb-close');
+  const closeElements = document.querySelectorAll('.mweb-mobile-fork a[href="#"], .mweb-mobile-fork a.mweb-close');
   closeElements.forEach((element) => {
     element.addEventListener('click', (event) => {
       event.preventDefault();


### PR DESCRIPTION
## Summary

Fixes the dismissable continue button selector to work on localized geos.

---

## Jira Ticket

Resolves: n/a

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/fr/express/ |
| **After**   | https://dismissable-cta-hotfix--express-milo--adobecom.aem.page/fr/express/?martech=off |

---

## Verification Steps

- Load in mobile Android emulator/phone
- The continuer button should work in dev branch but not in stage

---

## Potential Regressions

- https://dismissable-cta-hotfix--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
