### PR TITLE
lingo-poc dynamic link countrified

### DIFF
--- a/express/code/blocks/gen-ai-cards/gen-ai-cards.js
+++ b/express/code/blocks/gen-ai-cards/gen-ai-cards.js
@@ -235,6 +235,23 @@ function constructPayload(block) {
   return payload;
 }
 
+async function convertCountryLink(block) {
+  const { getCountry } = await import('../../scripts/utils/location-utils.js');
+  const country = await getCountry();
+  if (country.toLowerCase() !== 'ch') {
+    return;
+  }
+  const { prefix } = getConfig().locale;
+  const queryIndexJson = await fetch(`${prefix}/express/lingo/query-index.json`).then((res) => res.json());
+  const links = [...block.querySelectorAll('a')];
+  links.forEach((link) => {
+    const countrifiedLink = new URL(link.href).pathname.replace(`${prefix}`, `${prefix}/ch`);
+    if (queryIndexJson.data.some(({ path }) => path === countrifiedLink)) {
+      link.href = countrifiedLink;
+    }
+  });
+}
+
 export default async function decorate(block) {
   ({ createTag, getConfig } = await import(`${getLibs()}/utils/utils.js`));
   addTempWrapperDeprecated(block, 'gen-ai-cards');
@@ -255,6 +272,9 @@ export default async function decorate(block) {
   const payload = constructPayload(block);
   decorateHeading(block, payload);
   await decorateCards(block, payload);
+  if (new URLSearchParams(window.location.search).get('lingo')) {
+    await convertCountryLink(block);
+  }
   if (block.classList.contains('homepage')) {
     await buildCarousel('', block.querySelector('.gen-ai-cards-cards'));
   } else {


### PR DESCRIPTION
## Summary

Added url update if ?lingo exists for lingo poc.

---


## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/lingo/?lingo=1 |
| **After**   | https://lingo-poc-2--express-milo--adobecom.aem.page/express/lingo/?lingo=1&martech=off |

---

## Verification Steps

- On dev branch, the footer's lang-picker should be working with the url param. On stage it would fail.

---

## Potential Regressions

- Gated by USP so should be very safe
