### PR TITLE
Discover - TOC Links Should Highlight When TOC Just Above Header on Mobile / Tablet

### DIFF
--- a/express/code/blocks/toc-seo/toc-seo.js
+++ b/express/code/blocks/toc-seo/toc-seo.js
@@ -322,8 +322,14 @@ function updateActiveTOCLink(toc) {
 
   // Special handling for mobile/tablet sticky mode
   const isSticky = toc.classList.contains('toc-mobile-fixed');
-  let offset;
 
+  // On mobile/tablet, only do active header detection when TOC is sticky
+  if (window.innerWidth < 1024 && !isSticky) {
+    // TOC is not sticky on mobile/tablet, so don't highlight anything
+    return;
+  }
+
+  let offset;
   if (isSticky && window.innerWidth < 1024) {
     // When sticky on mobile/tablet, look for header positioned just below the sticky TOC
     const stickyBottom = tocTitleRect.bottom + 20; // Bottom of sticky TOC + buffer
@@ -343,13 +349,14 @@ function updateActiveTOCLink(toc) {
   }));
 
   if (isSticky && window.innerWidth < 1024) {
-    // For sticky mobile/tablet: use trigger lines (140px above each header)
+    // For sticky mobile/tablet: use trigger lines (40px above each header)
     const currentScrollTop = window.pageYOffset + offset; // Current scroll position
 
     // Find which trigger line we've most recently crossed
     for (const { element, rect } of headerRects) {
       const headerAbsoluteTop = window.pageYOffset + rect.top;
       const triggerLine = headerAbsoluteTop - 40; // 40px above header (landing spot)
+
       if (currentScrollTop >= triggerLine) {
         activeHeader = element; // Keep updating until we find the last crossed trigger
       } else {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR:
* On mobile / tablet the relevant TOC link gets highlighted when are just above the relevant section

---

## Jira Ticket

Resolves: [MWPW-179084](https://jira.corp.adobe.com/browse/MWPW-179084)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.hlx.page/drafts/jsandlan/discover-redesign |
| **After**   | https://toc-mobile-link-highlight--express-milo--adobecom.hlx.page/drafts/jsandlan/discover-redesign?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
1. Open https://stage--express-milo--adobecom.hlx.page/drafts/jsandlan/discover-redesign
2. Go to a tablet or mobile viewport and scroll down until the TOC becomes sticky.
3. Click on a link in the TOC. The TOC will close.
4. Reopen the TOC and notice the section the user has been brought to does not show the relevant TOC link highlighted.

- What to expect **before** and **after** the change.
1. Open https://toc-mobile-link-highlight--express-milo--adobecom.hlx.page/drafts/jsandlan/discover-redesign
2. Go to a tablet or mobile viewport and scroll down until the TOC becomes sticky.
3. Click on a link in the TOC. The TOC will close.
4. Reopen the TOC and notice the highlighted link is relevant to the section the user has been brought to.



---

## Potential Regressions

---

## Additional Notes

