### PR TITLE
adjusted max-width of the frictionless quick action button container …

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.css
@@ -6,7 +6,7 @@
 }
 
 .frictionless-quick-action video, .frictionless-quick-action img:not(.icon) {
-    max-width: var(--frictionless-quick-action-video-width);
+    max-width: 100%;
 }
 
 .frictionless-quick-action {
@@ -39,6 +39,7 @@
     min-height: 697px;
     max-width: 1440px;
     width: 100%;
+    height: 667px;
     margin: auto;
     transition: opacity 0.2s;
 }
@@ -61,7 +62,7 @@
     position: relative;
     right: 5px;
     width: var(--frictionless-quick-action-video-width);
-    min-height: var(--frictionless-quick-action-video-height);
+    max-width: 100%;
 }
 
 .frictionless-quick-action .fqa-container > div:nth-child(2) {
@@ -93,15 +94,9 @@
 .frictionless-quick-action .dropzone {
     flex-grow: 1;
     position: relative;
-    background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
     background-size: calc(100% - 48px) 100%;
-}
-
-.frictionless-quick-action .dropzone > * {
-    padding-left: 36px;
-    padding-right: 36px;
 }
 
 .frictionless-quick-action .dropzone > * {
@@ -138,6 +133,9 @@
 .frictionless-quick-action .fqa-container > div:nth-child(2) > p:last-of-type {
     margin: 15px 0 0;
     font-size: 0.75rem;
+    max-width: 90vw;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .frictionless-quick-action .free-plan-widget {
@@ -155,9 +153,6 @@
 
 main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkmark {
     background-color: #f06dad;
-}
-.frictionless-quick-action .quick-action-container {
-    height: 667px;
 }
 
 .frictionless-quick-action .quick-action-container > * {
@@ -231,7 +226,7 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
         background-image: url('/express/code/icons/dash-rectangle.svg');
     }
     .frictionless-quick-action video {
-        max-width: var(--frictionless-quick-action-video-width);
+        max-width: 100%;
     }
 
 }
@@ -240,12 +235,6 @@ main .section .frictionless-quick-action .free-plan-widget img.icon.icon-checkma
     .frictionless-quick-action .quick-action-container#resize-image-container {
         height: 1000px;
     }
-}
-
-.frictionless-quick-action .fqa-container > div:nth-child(2) > p:last-of-type{
-    max-width: 90vw;
-    margin-left: auto;
-    margin-right: auto;
 }
 
 .dropzone p:first-child.hidden {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR:

Adjusted max-width of the frictionless quick action button container to be 100% so that button does not get hidden at very small browser widths. Combined some redundantly declared CSS selectors.

---

## Jira Ticket

Resolves: [MWPW-177915](https://jira.corp.adobe.com/browse/MWPW-177915)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/drafts/maxn/remove-background-maxn |
| **After**   | https://MWPW-177915--express-milo--adobecom.aem.page/drafts/maxn/remove-background-maxn?martech=off |

---

## Verification Steps
- Steps to reproduce the issue or view the new feature.

1. Open https://stage--express-milo--adobecom.aem.page/drafts/maxn/remove-background-maxn
2. Open Browser developer tools
3. Click the toggle device icon or type Cmd+Shift+M to enter into the mobile view of the page
4. Adjust the browser width down to 320px

Note: This issue will only occur if you open the page while in the regular desktop browser mode and then switch to the mobile view in order to resize the browser width. If you load the page in the mobile view, it will load / render the mobile treatment of this block in which this issue does not occur.

- What to expect **before** and **after** the change.

Before: Play / Pause button is exceeding the width of the browser window and is getting hidden / cut-off, creating an accessibility issue.

After: Play / Pause button remains positioned at the bottom right of the video as it shrinks down.


---

## Potential Regressions

This block is featured on a lot of pages, here are a few:
- https://main--express-milo--adobecom.aem.live/br/express/feature/image/remove-background/jpg-to-png/transparent
- https://main--express-milo--adobecom.aem.live/br/express/feature/image/remove-background/logo
- https://main--express-milo--adobecom.aem.live/br/express/feature/image/remove-background/white
- https://main--express-milo--adobecom.aem.live/br/express/feature/image/resize/linkedin

I checked a lot of them and noticed no regressions.

---

## Additional Notes

As mentioned, issue is only reproducible if you open the page while in the regular desktop browser mode and then switch to the mobile view in order to resize the browser width. If you load the page in the mobile view, it will load / render the mobile treatment of this block in which this issue does not occur.