### PR TITLE
[MWPW-155657][Test] Template-x tworow experiment

### DIFF
--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3220,7 +3220,7 @@ main .template-x.tworow .template-2x2-col {
   width: min(260px, var(--ax-grid-6-col-width));
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  justify-content: center;
   flex: 0 0 auto;
 }
 
@@ -3247,11 +3247,11 @@ main .template-x.tworow .toolbar-wrapper .wrapper-functions {
 
 main .template-x.tworow .template-2x2-col .template {
   justify-content: flex-start;
+  min-height: 90px;
 }
 
 main .template-x.tworow .template-2x2-col .template.placeholder {
   max-height: 200px;
-  min-height: initial;
   width: calc(100% - 10px);
   max-width: initial;
   margin: 5px;
@@ -3259,7 +3259,8 @@ main .template-x.tworow .template-2x2-col .template.placeholder {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: var(--spacing-200)
+  gap: 4px;
+  padding: 5px;
 }
 
 main .template-x.tworow .template-2x2-col .template.placeholder.tall {
@@ -3286,7 +3287,7 @@ main .template-x.tworow .template-2x2-col .template.placeholder div:nth-of-type(
 main .template-x.tworow .template-2x2-col .template .still-wrapper img:not(.icon) {
   width: 100%;
   height: auto;
-  max-height: 200px;
+  max-height: 190px;
 }
 
 /* Last variant: template-tworow END */

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3199,7 +3199,7 @@ main .template-x.horizontal.tabbed.fullwidth .view-all-link-wrapper{
 main .template-x.tworow .template-x-inner-wrapper.gallery {
   justify-content: flex-start;
   /* undo legacy weird styles */
-  max-width: initial;;
+  max-width: initial;
   margin-left: initial;
   margin-right: initial;
   margin-bottom: initial;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3250,6 +3250,10 @@ main .template-x.tworow .template-2x2-col .template {
   min-height: 90px;
 }
 
+main .template-x.horizontal.tworow .template-2x2-col .template .button-container {
+  margin-left: initial;
+}
+
 main .template-x.tworow .template-2x2-col .template.placeholder {
   max-height: 200px;
   width: calc(100% - 10px);

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3217,7 +3217,7 @@ main .template-x.tworow .gallery-control {
 }
 
 main .template-x.tworow .template-2x2-col {
-  width: min(260px, var(--ax-grid-6-col-width));
+  width: min(260px, var(--ax-grid-5-col-width));
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3194,6 +3194,68 @@ main .template-x.horizontal.tabbed.fullwidth .view-all-link-wrapper{
   margin-bottom: 0px;
 }
 
+/* Last variant: template-tworow */
+
+main .template-x.tworow .template-x-inner-wrapper.gallery {
+  justify-content: flex-start;
+  /* undo legacy weird styles */
+  max-width: initial;;
+  margin-right: initial;
+  margin-left: var(--ax-grid-margin);
+  margin-bottom: initial;
+  margin-block: initial;
+  padding-left: initial;
+  padding-right: initial;
+}
+
+main .template-x.tworow .gallery-control {
+  padding-top: var(--spacing-200);
+}
+
+main .template-x.tworow .template-2x2-col {
+  display: flex;
+  flex-direction: column;
+  width: var(--ax-grid-6-col-width);
+  flex: 0 0 auto;
+}
+
+main .template-x.tworow .template-2x2-col .template {
+  justify-content: flex-start;
+}
+
+main .template-x.tworow .template-2x2-col .template.placeholder {
+  max-height: 200px;
+  width: calc(100% - 10px);
+  max-width: initial;
+  margin: 5px;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--spacing-200)
+}
+
+main .template-x.tworow .template-2x2-col .template.placeholder div:first-of-type {
+  max-width: initial;
+  height: initial;
+}
+
+main .template-x.tworow .template-2x2-col .template.placeholder .icon {
+  width: 36px;
+}
+
+main .template-x.tworow .template-2x2-col .template.placeholder div:nth-of-type(2) {
+  max-width: initial;
+  position: static;
+  padding-top: initial;
+}
+
+main .template-x.tworow .template-2x2-col .template .still-wrapper img:not(.icon) {
+  width: 100%;
+  height: auto;
+  max-height: 200px;
+}
+
+/* Last variant: template-tworow END */
+
 @media (min-width: 768px) {
   main .template-x.horizontal.tabbed.fullwidth .view-all-link-wrapper{
     margin-top:  var(--spacing-400);

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3206,17 +3206,42 @@ main .template-x.tworow .template-x-inner-wrapper.gallery {
   margin-block: initial;
   padding-left: initial;
   padding-right: initial;
+
+  padding-bottom: 20px;
+  padding-top: 28px;
 }
 
 main .template-x.tworow .gallery-control {
   padding-top: var(--spacing-200);
+  padding-right: 20px;
 }
 
 main .template-x.tworow .template-2x2-col {
   display: flex;
   flex-direction: column;
-  width: var(--ax-grid-6-col-width);
+  width: min(260px, var(--ax-grid-6-col-width));
   flex: 0 0 auto;
+}
+
+main .template-x.tworow .toolbar-wrapper .api-templates-toolbar {
+  margin-bottom: 0;
+}
+
+main .template-x.tworow .toolbar-wrapper .wrapper-functions {
+  display: none;
+}
+
+@media (min-width: 1200px) {
+  main .template-x.tworow .toolbar-wrapper .wrapper-functions {
+    display: flex;
+  }
+}
+
+@media (min-width: 900px) {
+  /* undo legacy style */
+  main .template-x.tworow.horizontal .template-2x2-col .template {
+    margin: 5px;
+  }
 }
 
 main .template-x.tworow .template-2x2-col .template {

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3254,12 +3254,6 @@ main .template-x.horizontal.tworow .template-2x2-col .template .button-container
   margin-left: initial;
 }
 
-/* main .template-x.horizontal.tworow .template-2x2-col .template .button-container .media-wrapper {
-  width: initial;
-  height: initial;
-  max-height: 200px;
-} */
-
 main .template-x.horizontal.tworow .template-2x2-col .template .button-container .media-wrapper video,
 main .template-x.horizontal.tworow .template-2x2-col .template .button-container .media-wrapper img {
   object-fit: contain;

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3217,9 +3217,10 @@ main .template-x.tworow .gallery-control {
 }
 
 main .template-x.tworow .template-2x2-col {
+  width: min(260px, var(--ax-grid-6-col-width));
   display: flex;
   flex-direction: column;
-  width: min(260px, var(--ax-grid-6-col-width));
+  justify-content: space-between;
   flex: 0 0 auto;
 }
 

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3200,19 +3200,25 @@ main .template-x.tworow .template-x-inner-wrapper.gallery {
   justify-content: flex-start;
   /* undo legacy weird styles */
   max-width: initial;;
+  margin-left: initial;
   margin-right: initial;
-  margin-left: var(--ax-grid-margin);
   margin-bottom: initial;
   margin-block: initial;
   padding-left: initial;
   padding-right: initial;
 
-  padding-bottom: 20px;
-  padding-top: 28px;
+  padding-bottom: var(--spacing-300);
+  padding-top: var(--spacing-300);
+
+  scroll-padding-left: var(--ax-grid-margin);
+}
+
+main .template-x.tworow .template-x-inner-wrapper.gallery .gallery--item:first-of-type {
+  /* prevent left clipping after scroll */
+  margin-left: var(--ax-grid-margin);
 }
 
 main .template-x.tworow .gallery-control {
-  padding-top: var(--spacing-200);
   padding-right: 20px;
 }
 

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3250,16 +3250,24 @@ main .template-x.tworow .template-2x2-col .template {
 
 main .template-x.tworow .template-2x2-col .template.placeholder {
   max-height: 200px;
+  min-height: initial;
   width: calc(100% - 10px);
   max-width: initial;
   margin: 5px;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
   justify-content: center;
   gap: var(--spacing-200)
 }
 
+main .template-x.tworow .template-2x2-col .template.placeholder.tall {
+  flex-direction: column;
+}
+
 main .template-x.tworow .template-2x2-col .template.placeholder div:first-of-type {
   max-width: initial;
+  width: initial;
   height: initial;
 }
 
@@ -3269,6 +3277,7 @@ main .template-x.tworow .template-2x2-col .template.placeholder .icon {
 
 main .template-x.tworow .template-2x2-col .template.placeholder div:nth-of-type(2) {
   max-width: initial;
+  min-height: initial;
   position: static;
   padding-top: initial;
 }

--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -3254,6 +3254,17 @@ main .template-x.horizontal.tworow .template-2x2-col .template .button-container
   margin-left: initial;
 }
 
+/* main .template-x.horizontal.tworow .template-2x2-col .template .button-container .media-wrapper {
+  width: initial;
+  height: initial;
+  max-height: 200px;
+} */
+
+main .template-x.horizontal.tworow .template-2x2-col .template .button-container .media-wrapper video,
+main .template-x.horizontal.tworow .template-2x2-col .template .button-container .media-wrapper img {
+  object-fit: contain;
+}
+
 main .template-x.tworow .template-2x2-col .template.placeholder {
   max-height: 200px;
   width: calc(100% - 10px);

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -289,7 +289,7 @@ function adjustPlaceholderDimensions(block, props, tmplt, option) {
   props.placeholderFormat = ratios;
   if (!ratios[1]) return;
   if (block.classList.contains(TWO_ROW)) {
-    // fixed width + dynamic height
+    // fixed width + height calculated at load time
     const width = Math.max(60, (window.innerWidth - 10) / 2);
     const height = Math.min(200, width / (ratios[0] / ratios[1]));
     if (height >= 100) tmplt.classList.add('tall');

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1769,6 +1769,7 @@ async function buildTemplateList(block, props, type = []) {
     await processContentRow(block, props);
   }
   if (props.experiment) block.classList.add(props.experiment);
+  if (getMetadata('template-experiment')) block.classList.add(getMetadata('template-experiment'));
 
   const { templates, fallbackMsg } = await fetchAndRenderTemplates(props);
 

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1850,6 +1850,8 @@ function determineTemplateXType(props) {
   if (props.print && props.print.toLowerCase() === 'flyer') type.push('flyer');
   if (props.print && props.print.toLowerCase() === 't-shirt') type.push('t-shirt');
 
+  if (props.experiment) type.push(props.experiment);
+
   variant = type;
   return type;
 }

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -172,8 +172,8 @@ async function formatHeadingPlaceholder(props) {
       toolBarHeading = toolBarHeading
         .replace('{{quantity}}', props.fallbackMsg ? '0' : templateCount)
         .replace('quantity', props.fallbackMsg ? '0' : templateCount)
-        .replace('{{Type}}', titleCase(getMetadata('short-title') || getMetadata('q') || getMetadata('topics')))
-        .replace('{{type}}', getMetadata('short-title') || getMetadata('q') || getMetadata('topics'));
+        .replace('{{Type}}', titleCase(getMetadata('short-title') || getMetadata('q') || getMetadata('topics') || ''))
+        .replace('{{type}}', getMetadata('short-title') || getMetadata('q') || getMetadata('topics') || '');
       if (region === 'fr') {
         toolBarHeading.split(' ').forEach((word, index, words) => {
           if (index + 1 < words.length) {
@@ -386,14 +386,13 @@ function chunkPairs(arr) {
 async function build2by2(parentContainer, block) {
   // preserve placeholder
   const placeholder = parentContainer.querySelector('.placeholder');
-  console.log({placeholder});
-  // bruteforce cleanup
-  [...parentContainer.querySelectorAll('.template-2x2-col')].forEach((col) => col.remove());
-  const pairs = chunkPairs([...parentContainer.querySelectorAll('.template')]);
-  const cols = pairs.map((pair) => createTag('div', { class: 'template-2x2-col' }, pair));
-  // cols.forEach((col) => innerWrapper.append(col));
-  parentContainer.append(...cols);
+  const oldCols = [...parentContainer.querySelectorAll('.template-2x2-col')];
+  // cleanup
+  oldCols.forEach((col) => col.remove());
   // break into 2 rows per column
+  const pairs = chunkPairs([oldCols.length ? placeholder : null, ...parentContainer.querySelectorAll('.template')].filter(Boolean));
+  const cols = pairs.map((pair) => createTag('div', { class: 'template-2x2-col' }, pair));
+  parentContainer.append(...cols);
   const { control } = await buildGallery(cols, parentContainer);
   const oldControl = block.querySelector('.gallery-control');
   if (oldControl) {

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -291,7 +291,7 @@ function adjustPlaceholderDimensions(block, props, tmplt, option) {
   if (block.classList.contains(TWO_ROW)) {
     // fixed width + dynamic height
     const width = Math.max(60, (window.innerWidth - 10) / 2);
-    const height = width / (ratios[0] / ratios[1]);
+    const height = Math.min(200, width / (ratios[0] / ratios[1]));
     if (height >= 100) tmplt.classList.add('tall');
     tmplt.style = `height: ${height}px`;
     return;

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -1768,8 +1768,6 @@ async function buildTemplateList(block, props, type = []) {
   if (!props.templateStats) {
     await processContentRow(block, props);
   }
-  if (props.experiment) block.classList.add(props.experiment);
-  if (getMetadata('template-experiment')) block.classList.add(getMetadata('template-experiment'));
 
   const { templates, fallbackMsg } = await fetchAndRenderTemplates(props);
 
@@ -1917,8 +1915,6 @@ function determineTemplateXType(props) {
   if (props.print && props.print.toLowerCase() === 'flyer') type.push('flyer');
   if (props.print && props.print.toLowerCase() === 't-shirt') type.push('t-shirt');
 
-  if (props.experiment) type.push(props.experiment);
-
   variant = type;
   return type;
 }
@@ -1930,6 +1926,15 @@ export default async function decorate(block) {
   });
   block.dataset.blockName = 'template-x';
   const props = constructProps(block);
+  if (getMetadata('template-experiment') && !props.experiment) {
+    props.experiment = getMetadata('template-experiment');
+  }
+  if (props.experiment) block.classList.add(props.experiment);
+  if (block.classList.contains(TWO_ROW)) {
+    // overriding variants for tworow experimentation
+    props.orientation = 'horizontal';
+    props.width = 'full';
+  }
   block.innerHTML = '';
   await buildTemplateList(block, props, determineTemplateXType(props));
 }

--- a/express/code/blocks/template-x/template-x.js
+++ b/express/code/blocks/template-x/template-x.js
@@ -289,6 +289,11 @@ function adjustPlaceholderDimensions(block, props, tmplt, option) {
   props.placeholderFormat = ratios;
   if (!ratios[1]) return;
   if (block.classList.contains(TWO_ROW)) {
+    // fixed width + dynamic height
+    const width = Math.max(60, (window.innerWidth - 10) / 2);
+    const height = width / (ratios[0] / ratios[1]);
+    if (height >= 100) tmplt.classList.add('tall');
+    tmplt.style = `height: ${height}px`;
     return;
   }
   if (block.classList.contains('horizontal')) {


### PR DESCRIPTION
## Summary

Added a new tworow variant/experiment that can be enabled via page metadata. It will be tested on template pages.

---

## Jira Ticket

Resolves: https://jira.corp.adobe.com/browse/MWPW-155657

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/templates/flyer?martech=off |
| **After**   | https://template-carousel-2by2--express-milo--adobecom.aem.page/drafts/jingle/template-x-two-rows?martech=off |

---

## Verification Steps

- Visit the branch url, and the block itself should be functional

---

## Potential Regressions

- Everything should already be guarded through authoring so releasing the PR itself shouldn't cause any effects
- https://template-carousel-2by2--express-milo--adobecom.aem.page/express/templates/flyer?martech=off

