### PR TITLE
adjusted CSS of discovery-cards flip variant

### DIFF
--- a/express/code/blocks/discover-cards/discover-cards.css
+++ b/express/code/blocks/discover-cards/discover-cards.css
@@ -234,7 +234,8 @@ main .section .discover-cards {
 
 @media (min-width: 1200px) {
   .discover-cards.flip {
-    height: 470px;
+    min-height: 470px;
+    height: 100%;
     padding-bottom: var(--spacing-800);
   }
 }
@@ -311,8 +312,7 @@ main .section .discover-cards {
   min-width: initial;
   width: 250px;
   max-width: initial;
-  height: 380px;
-  max-height: 380px;
+  height: 100%;
   cursor: pointer;
 }
 
@@ -323,6 +323,7 @@ main .section .discover-cards {
   text-align: center;
   transition: transform 350ms ease-out;
   transform-style: preserve-3d;
+  display: grid;
 }
 
 .discover-cards.flip .card.is-flipped .flip-card-inner {
@@ -333,7 +334,6 @@ main .section .discover-cards {
 .discover-cards.flip .flip-card-back {
   font-size: var(--heading-font-size-s);
   text-align: left;
-  position: absolute;
   width: 100%;
   height: 100%;
   -webkit-backface-visibility: hidden;
@@ -342,9 +342,9 @@ main .section .discover-cards {
   border-radius: 16px;
   padding: var(--spacing-500) var(--spacing-400);
   box-sizing: border-box;
+  grid-area: 1 / 1;
 }
 .discover-cards.flip .flip-card-back {
-  position: absolute;
   width: 100%;
   height: 100%;
   padding: 0;


### PR DESCRIPTION
## Summary

Adjusted CSS of discovery-cards flip variant in order to pass accessibility tests.

---

## Jira Ticket

Resolves: [MWPW-177677](https://jira.corp.adobe.com/browse/MWPW-177677)

---

## Test URLs
| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/drafts/maxn/maxn-photo-collage |
| **After**   | https://mwpw-177677--express-milo--adobecom.aem.page/drafts/maxn/maxn-photo-collage?martech=off |

---

## Verification Steps

- Steps to reproduce the issue
1. Open https://stage--express-milo--adobecom.aem.page/drafts/maxn/maxn-photo-collage
2. Scroll to the section with the flippable discover cards.
3. Run the accessibility text spacing tool.
Tool documented here: https://dylanb.github.io/bookmarklets.html
Tool found here: https://dylanb.github.io/bookmarklets.html

- Steps to view the new feature
1. Open https://mwpw-177677--express-milo--adobecom.aem.page/drafts/maxn/maxn-photo-collage?martech=off
2. Follow Steps 2 and 3 above.

Before:
Notice the text of the card getting cut off at the bottom edge of the card. 

After:
Notice the height of the card adjusting to ensure that the text is fully visible and no longer getting cut off.
 
---

## Potential Regressions

This block is featured on a lot of pages, here are a few:

- https://www.adobe.com/express/create/photo-collage
- https://www.adobe.com/express/business
- https://www.adobe.com/express/business/teams
- https://www.adobe.com/express/ambassadors

Note: These are all the default version of the discovery-cards component. Could not find another instance of the flippable cards variant. I checked all that I could find and noticed no regressions.

---

## Additional Notes

No additional notes. 
