### PR TITLE
removed IntersectionObserver on search-marquee allowing Search component to be initialized to blockMediator on page load

### DIFF
--- a/express/code/blocks/search-marquee/search-marquee.js
+++ b/express/code/blocks/search-marquee/search-marquee.js
@@ -39,21 +39,10 @@ function initSearchFunction(block, searchBarWrapper) {
 
   clearBtn.style.display = 'none';
 
-  const searchBarWatcher = new IntersectionObserver((entries) => {
-    if (!entries[0].isIntersecting) {
-      BlockMediator.set('stickySearchBar', {
-        element: searchBarWrapper.cloneNode(true),
-        loadSearchBar: true,
-      });
-    } else {
-      BlockMediator.set('stickySearchBar', {
-        element: searchBarWrapper.cloneNode(true),
-        loadSearchBar: false,
-      });
-    }
-  }, { rootMargin: '0px', threshold: 1 });
-
-  searchBarWatcher.observe(searchBarWrapper);
+  BlockMediator.set('stickySearchBar', {
+    element: searchBarWrapper.cloneNode(true),
+    loadSearchBar: true,
+  });
 
   searchBar.addEventListener('click', (e) => {
     e.stopPropagation();


### PR DESCRIPTION
## Summary

removed IntersectionObserver on search-marquee allowing Search component to be initialized to blockMediator on page load

---

## Jira Ticket

Resolves: [MWPW-178663](https://jira.corp.adobe.com/browse/MWPW-178663)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.page/express/templates/poster |
| **After**   | https://MWPW-178663--express-milo--adobecom.aem.page/express/templates/poster?martech=off |

---

## Verification Steps

1. Open https://stage--express-milo--adobecom.aem.page/express/templates/poster
2. Notice the Search icon in the search-marquee below the banner does not appear until you scroll down the page. 

Steps to view the new feature

1. Open https://MWPW-178663--express-milo--adobecom.aem.page/express/templates/poster?martech=off
2. Notice the Search icon is present in the search-marquee on page load.

---

## Potential Regressions

Any of the template pages with the search-marquee component.

- https://www.adobe.com/express/templates/poster
- https://www.adobe.com/express/templates/logo
- https://www.adobe.com/express/templates/logo/music?searchId=123600
- https://www.adobe.com/express/templates/brochure?searchId=439299
- https://www.adobe.com/express/templates/search?tasks=card-greeting&tasksx=card-greeting&phformat=1:1&topics=music&q=music&searchId=927493

Tested many and all look good. 

---

## Additional Notes

Looks like some formatting changes got picked up in my template-x.js file. This makes it look like a lot of adjustments were made when in reality only a few lines were changed. Where we were subscribed to the blockMediator to provide the event of the stickySeachBar getting set, we now simply access it directly, since the subscription is no longer needed, since it wont become set / unset on user scroll. 
