### PR TITLE
MWPW-181168-2: Fix PR reminder workflow to only run on schedule, not on push events

### DIFF
--- a/.github/workflows/pr-reminder-daily.yml
+++ b/.github/workflows/pr-reminder-daily.yml
@@ -7,10 +7,6 @@ on:
     - cron: '0 22 * * *'  # 10 PM UTC (2 PM PST)
     # Testing: every 5 minutes (when test-daily-reminder label exists)
     - cron: '*/5 * * * *'  # Every 5 minutes (test mode only)
-  push:
-    branches:
-      - main
-      - stage
   workflow_dispatch: # Allow manual trigger for testing
 
 jobs:
@@ -19,7 +15,6 @@ jobs:
     if: |
       github.repository_owner == 'adobecom' &&
       (github.event_name == 'workflow_dispatch' || 
-       github.event_name == 'push' || 
        github.event_name == 'schedule')
     
     steps:


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR.

Follow up to https://github.com/adobecom/express-milo/pull/630
- Remove the push notifications polluting the scheduled notifications

---

## Jira Ticket

Resolves: [MWPW-181168](https://jira.corp.adobe.com/browse/MWPW-181168)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://MWPW-181168--express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
