### PR TITLE
[CCEX-200047]Frictionless experiment remove bg

### DIFF
--- a/express/code/scripts/utils/frictionless-utils.js
+++ b/express/code/scripts/utils/frictionless-utils.js
@@ -116,10 +116,19 @@ export const EXPERIMENTAL_VARIANTS = [
   'qa-in-product-control',
 ];
 
+export const EXPERIMENTAL_VARIANTS_PROMOID_MAP = {
+  'qa-in-product-variant1': '98SH4CD4',
+  'qa-in-product-variant2': '9DJJ47N3',
+  'qa-nba': '9J8K43X2',
+  'qa-in-product-control': '91BF4LV6',
+};
+
 // Quick actions allowed in frictionless upload feature
 export const FRICTIONLESS_UPLOAD_QUICK_ACTIONS = {
   videoEditor: 'edit-video',
   imageEditor: 'edit-image',
+  removeBackgroundVariant1: 'qa-in-product-variant1',
+  removeBackgroundVariant2: 'qa-in-product-variant2',
 };
 
 // Route paths map corresponding to the express routes


### PR DESCRIPTION
## Summary

In this PR, we added the promoid for the Remove Background QA experiments variants.

For Variant 1 (qa-in-product-variant1) and Variant 2 (qa-in-product-variant2), we are launching the Express Editor directly using the upload service.
As part of this work, we also updated the CTA href to point to the Express Editor (the changes are currently in the draft doc).
for testing the variants are decided based on the 'variant' query param
control -> qa-in-product-control
variant1 -> qa-in-product-variant1
variant2 -> qa-in-product-variant2
variant3 -> qa-nba

Testing URL: https://frictionless-experiment--express-milo--adobecom.aem.page/drafts/shairilk/remove-background/?martech=off

---

## Jira Ticket

Resolved: [CCEX-200047](https://jira.corp.adobe.com/browse/CCEX-200047)
MWPW ticket: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://frictionless-experiment--express-milo--adobecom.aem.page/drafts/shairilk/remove-background/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://frictionless-experiment--express-milo--adobecom.aem.page/drafts/shairilk/remove-background/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
