### PR TITLE
[SEO Generic] Express DA | Accessibility issue - element fails WCAG color contrast standards

### DIFF
--- a/express/code/blocks/template-x/template-x.css
+++ b/express/code/blocks/template-x/template-x.css
@@ -2442,7 +2442,7 @@ nav ol.templates-breadcrumbs {
 nav ol.templates-breadcrumbs li {
   display: flex;
   padding: 5px 10px 5px 0;
-  color: var(--color-gray-500);
+  color: var(--color-gray-600);
 }
 
 nav ol.templates-breadcrumbs li a {


### PR DESCRIPTION
## Summary

Briefly describe the features or fixes introduced in this PR:
* increase contrast of template-breadcrumbs li to meet WCAG A11Y standards

---

## Jira Ticket

Resolves: [MWPW-181650](https://jira.corp.adobe.com/browse/MWPW-181650)

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/templates/logo |
| **After**   | https://a11y-template-li--express-milo--adobecom.aem.page/express/templates/logo/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://<branch>--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
