### PR TITLE
[CCEX-200047] Fixed the variant 1 and variant 2 not working

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -552,9 +552,13 @@ export default async function decorate(block) {
   cta.addEventListener('click', (e) => e.preventDefault(), false);
   // Fetch the base url for editor entry from upload cta and save it for later use.
   frictionlessTargetBaseUrl = cta.href;
-  if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1 || quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
-    const isStage = urlParams.get('hzenv') === 'stage';
-    frictionlessTargetBaseUrl = isStage ? 'https://stage.express.adobe.com/new' : 'https://express.adobe.com/new';
+  if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
+    || quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const isStage = urlParams.get('hzenv') === 'stage';
+      frictionlessTargetBaseUrl = isStage
+        ? 'https://stage.express.adobe.com/new'
+        : 'https://express.adobe.com/new';
   }
 
   const dropzoneHint = dropzone.querySelector('p:first-child');

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -552,12 +552,14 @@ export default async function decorate(block) {
   cta.addEventListener('click', (e) => e.preventDefault(), false);
   // Fetch the base url for editor entry from upload cta and save it for later use.
   frictionlessTargetBaseUrl = cta.href;
-  if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
-    || quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
-    const urlParams = new URLSearchParams(window.location.search);
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlVariant = urlParams.get('variant');
+  const variant = urlVariant || quickAction;
+  if (variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
+    || variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
     const isStage = urlParams.get('hzenv') === 'stage';
     frictionlessTargetBaseUrl = isStage
-      ? 'https://stage.express.adobe.com/new'
+      ? 'https://stage.projectx.corp.adobe.com/new'
       : 'https://express.adobe.com/new';
   }
 

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -554,11 +554,11 @@ export default async function decorate(block) {
   frictionlessTargetBaseUrl = cta.href;
   if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
     || quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const isStage = urlParams.get('hzenv') === 'stage';
-      frictionlessTargetBaseUrl = isStage
-        ? 'https://stage.express.adobe.com/new'
-        : 'https://express.adobe.com/new';
+    const urlParams = new URLSearchParams(window.location.search);
+    const isStage = urlParams.get('hzenv') === 'stage';
+    frictionlessTargetBaseUrl = isStage
+      ? 'https://stage.express.adobe.com/new'
+      : 'https://express.adobe.com/new';
   }
 
   const dropzoneHint = dropzone.querySelector('p:first-child');

--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -552,6 +552,11 @@ export default async function decorate(block) {
   cta.addEventListener('click', (e) => e.preventDefault(), false);
   // Fetch the base url for editor entry from upload cta and save it for later use.
   frictionlessTargetBaseUrl = cta.href;
+  if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1 || quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
+    const isStage = urlParams.get('hzenv') === 'stage';
+    frictionlessTargetBaseUrl = isStage ? 'https://stage.express.adobe.com/new' : 'https://express.adobe.com/new';
+  }
+
   const dropzoneHint = dropzone.querySelector('p:first-child');
   const gtcText = dropzone.querySelector('p:last-child');
   const actionColumn = createTag('div');


### PR DESCRIPTION
## Summary
In this PR i have updated the frictionlessTargetBaseUrl to point to express editor (stage or prod based on the query param)
for the variant 1 and variant 2 of our fricitonless remove background quic action expeirment.
Previously we were depending on the doc changes to read the base URL to point for our experiment.

After the fix the variantb 1 and variant 2 should work fine without any document changes.
Testing URL:
variant1- https://frictionless-cta-update--express-milo--adobecom.aem.page/?variant=qa-in-product-variant1&martech=off

Variant2- https://frictionless-cta-update--express-milo--adobecom.aem.page/?variant=qa-in-product-variant2&martech=off

---

## Jira Ticket

Resolves: [CCEX-200047](https://jira.corp.adobe.com/browse/CCEX-200047)
MWPW ticket: https://jira.corp.adobe.com/browse/MWPW-181495

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://main--express-milo--adobecom.aem.page/express/ |
| **After**   | https://frictionless-cta-update--express-milo--adobecom.aem.page/express/?martech=off |

---

## Verification Steps

- Steps to reproduce the issue or view the new feature.
- What to expect **before** and **after** the change.

---

## Potential Regressions

- https://frictionless-cta-update--express-milo--adobecom.aem.live/express/?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.
