### PR TITLE
[CCEX-200047] Fixed the variant 1 and variant 2 not working 

### DIFF
--- a/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
+++ b/express/code/blocks/frictionless-quick-action/frictionless-quick-action.js
@@ -552,12 +552,14 @@ export default async function decorate(block) {
   cta.addEventListener('click', (e) => e.preventDefault(), false);
   // Fetch the base url for editor entry from upload cta and save it for later use.
   frictionlessTargetBaseUrl = cta.href;
-  if (quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
-    || quickAction === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
-    const urlParams = new URLSearchParams(window.location.search);
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlVariant = urlParams.get('variant');
+  const variant = urlVariant || quickAction;
+  if (variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant1
+    || variant === FRICTIONLESS_UPLOAD_QUICK_ACTIONS.removeBackgroundVariant2) {
     const isStage = urlParams.get('hzenv') === 'stage';
     frictionlessTargetBaseUrl = isStage
-      ? 'https://stage.express.adobe.com/new'
+      ? 'https://stage.projectx.corp.adobe.com/new'
       : 'https://express.adobe.com/new';
   }
 


### PR DESCRIPTION
## Summary

In this PR, I’ve updated the frictionlessTargetBaseUrl to point to the Express editor (stage or prod, depending on the query parameter) for Variant 1 and Variant 2 of our Frictionless Remove Background Quick Action experiment.

Previously, the experiment depended on document changes to determine the base URL.
With this fix, both Variant 1 and Variant 2 should work correctly without requiring any updates to the document.

Testing URL:
variant1- https://frictionless-bugfix--express-milo--adobecom.aem.live/express/feature/image/remove-background?variant=qa-in-product-variant1&martech=off

Variant2- https://frictionless-bugfix--express-milo--adobecom.aem.live/express/feature/image/remove-background?variant=qa-in-product-variant2&martech=off

---

## Jira Ticket

Resolves: [CCEX-200047](https://jira.corp.adobe.com/browse/CCEX-200047)
MWPW ticket: https://jira.corp.adobe.com/browse/MWPW-181495

---

## Test URLs

| Env | URL |
|-------------|-----|
| **Before**  | https://stage--express-milo--adobecom.aem.live/express/feature/image/remove-background |
| **After**   | https://frictionless-bugfix--express-milo--adobecom.aem.live/express/feature/image/remove-background?martech=off |

---

## Verification Steps

- Before the change:
We were relying on the document for the redirection URL. Without the document update, Variant 1 and Variant 2 were redirecting to the ACOM home page instead of the intended target.
To reproduce this issue, try the following URLs (without the document change):
   - Variant 1: https://www.stage.adobe.com/express/feature/image/remove-background?variant=qa-in-product-variant1
   - Variant 2: https://www.stage.adobe.com/express/feature/image/remove-background?variant=qa-in-product-variant2

- After the change:
We removed the dependency on the document and hardcoded the redirection URL directly in the codebase.
To verify the fix, test using the URLs below:

   - Variant 1: https://frictionless-bugfix--express-milo--adobecom.aem.live/express/feature/image/remove-background?variant=qa-in-product-variant1&martech=off
   - Variant 2: https://frictionless-bugfix--express-milo--adobecom.aem.live/express/feature/image/remove-background?variant=qa-in-product-variant2&martech=off


---

## Potential Regressions

- https://frictionless-bugfix--express-milo--adobecom.aem.page/express/feature/image/remove-background?martech=off

---

## Additional Notes

(If applicable) Add context, related PRs, or known issues here.

