### PR TITLE
MWPW-200482 - Remove JIRA Epic field from .kodiak config

### DIFF
--- a/.kodiak/config.yaml
+++ b/.kodiak/config.yaml
@@ -18,7 +18,6 @@ notifications:
           tool_type:
             - "grype" # Exclude SBOM tickets which duplicate findings already created by snyk
       fields:
-        customfield_11800: MWPW-164516 # Jira epic security tickets will be assigned to.
         customfield_12900: # Team to whom tickets will be assigned
           value: Express dev
         watchers: # Everyone who is an admin on your repository should be a watcher.


### PR DESCRIPTION
Removing JIRA Epic field from .kodiak/config.yaml

URL for testing:

- Before: https://main--express-milo--adobecom.aem.page/express/?martech=off
- After: https://mwpw-200482--express-milo--adobecom.aem.page/express/?martech=off
